### PR TITLE
refactor(sql): Refactor autoload behavior in `Table` [#139](https://g…

### DIFF
--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -232,7 +232,14 @@ class Table(HasIdentifier):
         This version fully supports the main use cases.
 
     """
-    def __init__(self, name: str, metadata: MetaData, *columns: Column, **kwargs: Any):
+    def __init__(
+            self, 
+            name: str, 
+            metadata: MetaData, 
+            *columns: Column,
+            autoload_with: Optional[Engine] = None, 
+            **kwargs: Any
+    ):
         self.name = name
         """Table name."""
 
@@ -270,12 +277,11 @@ class Table(HasIdentifier):
         This is the Notion page id containing all the tables which belong to the same database. 
         """
 
-        if kwargs:
+        if autoload_with:
             if columns:
-                raise ArgumentError('Columns cannot be specified when using autoload_with keyword argument')
+                raise ArgumentError('Columns cannot be specified when using "autoload_with" keyword argument')
             
-            if 'autoload_with' in kwargs:
-                self._autoload(kwargs['autoload_with'])
+            self._autoload(autoload_with)
         
         if columns:
             # add user-declared columns
@@ -384,10 +390,7 @@ class Table(HasIdentifier):
         self._primary_key = PrimaryKeyConstraint(*table_pks)
 
     def _autoload(self, engine: Engine) -> None:
-        from normlite.engine.base import Inspector
-
-        inspector: Inspector = engine.inspect()
-        inspector.reflect_table(self)
+        engine._reflect_table(self)
 
     def _set_table_oid(self, oid: str) -> None:
         self._database_id = oid

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -244,3 +244,25 @@ def test_reflect_user_table_w_ddl(inspector: Inspector):
     assert 'is_active' in students.c
     assert len(students.primary_key.c) == 1
     assert students.primary_key.c._no_id == students.c._no_id
+
+def test_reflect_sys_tables_w_autoload(engine: Engine):
+    metadata = MetaData()
+    sys_tables = Table('tables', metadata, autoload_with=engine)
+    assert 'table_name' in sys_tables.c
+    assert 'table_schema' in sys_tables.c
+    assert 'table_catalog' in sys_tables.c
+    assert 'table_id' in sys_tables.c
+    assert len(sys_tables.primary_key.c) == 1
+    assert sys_tables.primary_key.c._no_id == sys_tables.c._no_id
+
+def test_reflect_user_table_w_autoload(engine: Engine):
+    create_students_db(engine)
+    metadata = MetaData()
+    students = Table('students', metadata, autoload_with=engine)
+
+    assert 'student_id' in students.c
+    assert 'name' in students.c
+    assert 'grade' in students.c
+    assert 'is_active' in students.c
+    assert len(students.primary_key.c) == 1
+    assert students.primary_key.c._no_id == students.c._no_id


### PR DESCRIPTION
…ithub.com/giant0791/normlite/issues/139)

This updated version fully leverages the new `Engine._reflect_table()` protected API and it introduces an explicit `autoload_with` argument in the `Table.__init__()`.

Closes #139