### PR TITLE
feat(sql): Reflect all tables in `MetaData` [#142](https://github.com…

### DIFF
--- a/docs/advanced-guide.md
+++ b/docs/advanced-guide.md
@@ -1,0 +1,54 @@
+
+# Reflection Pipeline Architecture (Advanced)
+
+This document explains how table reflection is implemented internally in normlite.
+
+## Core Insight
+
+**Reflection is a process, not a single statement**, but the execution pipeline only supports single-command execution.
+Normlite resolves this by orchestrating reflection at the **Engine level**.
+
+## Main Components
+
+### Inspector
+User-facing reflection API.
+
+### Engine
+Owns reflection orchestration via protected APIs such as `_reflect_table()`.
+
+### Executable
+Represents a single database command (e.g. `HasTable`, `ReflectTable`).
+
+### ExecutionContext
+Represents exactly one execution: one compiled statement, one cursor, one parameter set.
+
+## Pseudo-DDL Primitives
+
+- `HasTable`: checks for table existence
+- `ReflectTable`: reflects column metadata
+
+Each primitive executes exactly one command.
+
+## Row-Based Reflection
+
+Reflection results are returned as rows, one row per column:
+
+```text
+(name, type_engine, column_id, value)
+```
+
+This mirrors SQLAlchemy’s `information_schema.columns` model.
+
+## ReflectedTableInfo
+
+Intermediate structure that holds reflected column metadata and validates special columns.
+
+## Key Invariants
+
+1. One executable = one DB command
+2. ExecutionContext is single-use
+3. Engine owns orchestration
+4. DBAPI cursor remains dumb
+5. Reflection always returns rows
+
+Maintainers should preserve these invariants.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 
 get-started.md
 user-guide.md
+advanced-guide.md
 autoapi/index
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,11 +77,80 @@ You simply write SQL, and normlite keeps everything in sync.
 
 Future `normlite versions` will introduce structured migrations — but even then, upgrading will not require extra work from you.
 
-## That’s It — You’re Ready!
+# Table Reflection with the Inspector API
 
-With these basics in mind, you can start creating tables, inserting data, and building apps on top of Notion immediately.
+Normlite provides **table reflection** to let you inspect existing Notion databases and integrate them seamlessly into your application.
+Reflection allows you to discover table existence, column definitions, and to populate `Table` objects with their real schema — **without writing low-level API code**.
 
-Everything else (schema structure, naming rules, advanced metadata) is explained in the Advanced Concepts section — no need to worry about it now.
+## What is Table Reflection?
 
-Welcome to `normlite`.
-Let’s build something great.
+Table reflection is the process of **reading a database schema from Notion** and translating it into normlite objects such as:
+
+- `Table`
+- `Column`
+- `TypeEngine`
+
+Reflection is **read-only** and safe.
+
+## The Inspector API
+
+```python
+from normlite import inspect
+
+inspector = inspect(engine)
+```
+
+### has_table(table_name)
+
+```python
+if inspector.has_table("students"):
+    print("Table exists")
+```
+
+### get_columns(table_name)
+
+```python
+columns = inspector.get_columns("students")
+for col in columns:
+    print(col.name, col.type)
+```
+
+Returns a sequence of `ReflectedColumnInfo`.
+
+### reflect_table(table)
+
+```python
+from normlite import Table, MetaData
+
+metadata = MetaData()
+students = Table("students", metadata)
+inspector.reflect_table(students)
+```
+
+After reflection, the table is ready for queries.
+
+## The Schema API
+
+`Table` and `MetaData` provide a reflection API as well.
+
+### Table autoload_with
+
+```python
+from  normlite import Table, MetaData
+
+metadata = MetaData()
+students = Table("students", metadata, autoload_with=engine)
+```
+
+### Reflect all tables registered with MetaData
+```python
+from  normlite import Table, MetaData
+
+metadata = MetaData()
+students = Table("students", metadata)
+classes = Table("classes", metadata)
+exams = Table("exams", metadata)
+metadata.reflect(engine)
+```
+
+This API is very powerful because it enables to reflect all tables at once.

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -266,3 +266,25 @@ def test_reflect_user_table_w_autoload(engine: Engine):
     assert 'is_active' in students.c
     assert len(students.primary_key.c) == 1
     assert students.primary_key.c._no_id == students.c._no_id
+
+def test_reflect_all_w_metadata(engine: Engine):
+    create_students_db(engine)
+    metadata = MetaData()
+    sys_tables = Table('tables', metadata)
+    students = Table('students', metadata)
+    metadata.reflect(engine)
+
+    assert 'table_name' in sys_tables.c
+    assert 'table_schema' in sys_tables.c
+    assert 'table_catalog' in sys_tables.c
+    assert 'table_id' in sys_tables.c
+    assert len(sys_tables.primary_key.c) == 1
+    assert sys_tables.primary_key.c._no_id == sys_tables.c._no_id
+
+    assert 'student_id' in students.c
+    assert 'name' in students.c
+    assert 'grade' in students.c
+    assert 'is_active' in students.c
+    assert len(students.primary_key.c) == 1
+    assert students.primary_key.c._no_id == students.c._no_id
+


### PR DESCRIPTION
…/giant0791/normlite/issues/142)

This new version provide a powerful reflection API for all tables registered with a `MetaData` object. It uses the `Engine._reflect_table()` protected API under the wood.

- update documentation with user and advanced guide on reflection.
- update tests.

Closes #142