### PR TITLE
refactor(notiondbapi): Refactor cursor description in DBAPI `Cursor` …

### DIFF
--- a/src/normlite/_constants.py
+++ b/src/normlite/_constants.py
@@ -23,6 +23,7 @@ This module implements constants to be used in other modules of ``normlite``.
 
 """
 from enum import StrEnum
+import pdb
 
 class SpecialColumns(StrEnum):
     """Define enum constants for column names to access Notion-specific columns ("special columns").
@@ -56,11 +57,17 @@ class SpecialColumns(StrEnum):
     NO_IN_TRASH = "_no_in_trash"
     """Notion "in_trash" key for all objects."""
 
+    NO_CREATED_TIME = "_no_created_time"
+    """Notion "created_time" timestamp."""
+
     @classmethod
-    def values(cls) -> tuple[str, ...]:
+    def values(cls, is_dml: bool = True) -> tuple[str, ...]:
         """Provide all constants values as tuple.
         
         Helper class method for implementing is in tests.
+
+        .. versionchanged:: 0.9.0
+            This version introduces the paramater ``is_dml``.
 
         Example::
 
@@ -70,5 +77,22 @@ class SpecialColumns(StrEnum):
             >>> '_no_not_exists' in SpecialColumns.values()
             False
 
+        Args:
+            is_dml (bool, optional): If ``True``, it does not add the "_no_title" key (this is required for databases only). Defaults to True.
+
+        Returns:
+            tuple[str, ...]: A sequence containing all special columns names as plain strings.
         """
-        return tuple(m.value for m in cls)
+        values = ()
+        for m in cls:
+            if m.value == '_no_parent_id':
+                #skip: not implemented yet
+                continue
+
+            if m.value == '_no_title' and is_dml:
+                # skip: needed for DDL statements only
+                continue
+
+            values += (m.value, )
+        
+        return values

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -51,6 +51,7 @@ import copy
 
 from normlite.exceptions import ArgumentError
 from normlite.engine.interfaces import _CoreMultiExecuteParams, ExecutionOptions
+from normlite.sql.resultschema import SchemaInfo
 from normlite.utils import frozendict
 
 if TYPE_CHECKING:
@@ -371,7 +372,14 @@ class ExecutionContext:
         # extract the query params
         if 'query_params' in self.compiled_dict:
             self.query_params = self.compiled_dict['query_params']
-    
+
+        # inject schema info if invoked statement is not DDL
+        if self.invoked_stmt.is_ddl:
+            return
+        
+        schema = SchemaInfo.from_table(self.invoked_stmt.get_table(), self.compiled.result_columns())
+        self.cursor._inject_description(schema.as_sequence())
+
     def post_exec(self) -> None:
         """Perform row counting preservation after execution.
         

--- a/src/normlite/engine/row.py
+++ b/src/normlite/engine/row.py
@@ -44,7 +44,7 @@ class Row:
     
     def _process_ddl_row(self, row_data: tuple) -> None:
         col_name, col_type, col_id, col_value = row_data
-        is_special_col = col_name in SpecialColumns.values()
+        is_special_col = col_name in SpecialColumns.values(is_dml=False)
         type_factory = type_mapper[col_type]
         result_proc = type_factory.result_processor()
         self._values[0] = col_name

--- a/src/normlite/exceptions.py
+++ b/src/normlite/exceptions.py
@@ -98,3 +98,9 @@ class NoSuchTableError(NormliteError):
 
     .. versionadded:: 0.8.0
     """
+
+class NoSuchColumnError(InvalidRequestError):
+    """A nonexistent column is requested from a row.
+    
+    .. versionadded:: 0.9.0
+    """

--- a/src/normlite/notiondbapi/_model.py
+++ b/src/normlite/notiondbapi/_model.py
@@ -179,6 +179,7 @@ class NotionPage(NotionObject):
         properties: Sequence[NotionProperty],
         archived: Optional[bool] = None, 
         in_trash: Optional[bool] = None,
+        created_time: Optional[str] = None
     ):
         self.id = id
         """The page id as assigned by Notion."""
@@ -190,6 +191,8 @@ class NotionPage(NotionObject):
         self.in_trash = in_trash
         """The ``"in_trash"`` flag for this page. Defaults to ``None`` when
         the page is a newly created object."""
+
+        self.created_time = created_time
         
         self.properties = properties
         """The page ``"properties"`` object."""
@@ -226,6 +229,7 @@ class NotionDatabase(NotionObject):
         properties: Sequence[NotionProperty],
         archived: Optional[bool] = None, 
         in_trash: Optional[bool] = None,
+        created_time: Optional[str] = None,
     ):
 
         self.id = id
@@ -233,11 +237,12 @@ class NotionDatabase(NotionObject):
         self.title = title
         self.archived = archived
         self.in_trash = in_trash
+        self.created_time = created_time
         self.properties = properties
 
     def __repr__(self):
         prop_str = ", ".join([prop for prop in self.properties])
-        db_str = f'Database(id="{self.id}", title="{self.title}", archived={self.archived}, in_trash={self.in_trash}, properties={prop_str})'
+        db_str = f'Database(id="{self.id}", title="{self.title}", archived={self.archived}, in_trash={self.in_trash}, created_time={self.created_time}, properties={prop_str})'
         return db_str 
 
 

--- a/src/normlite/notiondbapi/_parser.py
+++ b/src/normlite/notiondbapi/_parser.py
@@ -118,18 +118,20 @@ def parse_page(payload: dict) -> NotionPage:
     id = payload["id"]
     archived = payload.get('archived')
     in_trash = payload.get('in_trash')
+    created_time = payload.get('created_time')
     properties = [
         parse_page_property(name, pdata) for name, pdata in payload.get("properties", {}).items()
     ]
-    return NotionPage(id=id, properties=properties, archived=archived, in_trash=in_trash)
+    return NotionPage(id=id, properties=properties, archived=archived, in_trash=in_trash, created_time=created_time)
     
 def parse_database(payload: dict) -> NotionDatabase:
     id = payload.get('id')
     title = payload.get('title')
     archived = payload.get('archived')
     in_trash = payload.get('in_trash')
+    created_time = payload.get('created_time')
     properties = [
         parse_database_property(name, pdata) for name, pdata in payload.get("properties", {}).items()
     ]
 
-    return NotionDatabase(id, '', {'title': title}, properties, archived, in_trash)
+    return NotionDatabase(id, '', {'title': title}, properties, archived, in_trash, created_time)

--- a/src/normlite/notiondbapi/compiler.py
+++ b/src/normlite/notiondbapi/compiler.py
@@ -158,6 +158,7 @@ class RowCompiler(NotionObjectCompiler):
             page.id,
             page.archived,
             page.in_trash,
+            page.created_time,
         ]
 
         visited_page.extend(special_columns)
@@ -172,6 +173,7 @@ class RowCompiler(NotionObjectCompiler):
             (SpecialColumns.NO_ID, DBAPITypeCode.ID, None, database.id,),
             (SpecialColumns.NO_ARCHIVED, DBAPITypeCode.CHECKBOX, None, database.archived,),
             (SpecialColumns.NO_IN_TRASH, DBAPITypeCode.CHECKBOX, None, database.in_trash,),
+            (SpecialColumns.NO_CREATED_TIME, DBAPITypeCode.TIMESTAMP, None, database.created_time),
             (SpecialColumns.NO_TITLE, DBAPITypeCode.TITLE, None, database.title)
         ]
         visited_database.extend(special_columns)

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -86,6 +86,21 @@ class ProgrammingError(DatabaseError):
     .. versionadded:: 0.8.0
 
     """
+
+class _Description:
+    """Internal DBAPI representation of cursor.description.
+    
+    .. versionadded:: 0.9.0
+    """
+
+    __slots__ = ("_entries",)
+
+    def __init__(self, entries: tuple[tuple, ...]):
+        self._entries = entries
+
+    def as_sequence(self) -> tuple[tuple, ...]:
+        return self._entries
+
 class Cursor:
     """Provide database base cursor functionalty according to the DBAPI 2.0 specification (PEP 249).
     
@@ -106,14 +121,14 @@ class Cursor:
         self._paramstyle: DBAPIParamStyle = 'named'
         """The default parameter style applied."""
 
-        self._description: tuple = None
+        self._description: Sequence[tuple] = None
         """Provide information describing one result column."""
 
         self._closed = False
         """Whether this cursor is closed. Always ``False`` after initialitation."""
 
     @property
-    def description(self) -> tuple:
+    def description(self) -> Optional[Sequence[tuple]]:
         """Provide the cursor description.
         
         This read-only attribute is a sequence of 7-item sequences.   
@@ -202,6 +217,10 @@ class Cursor:
             DBAPIParamStyle: The paramstyle currently in use.
         """
         return self._paramstyle
+    
+    def _inject_description(self, schema_entries: tuple[tuple, ...]) -> None:
+        description = _Description(schema_entries)
+        self._description = description.as_sequence()
 
     def _parse_object(self, obj: Dict[str, Any]) -> Tuple[tuple]:
         """Parse a Notion database or page from a list object into a list of tuples.
@@ -247,8 +266,6 @@ class Cursor:
                 'Only "page" or "database" objects supported.'
             )
     
-        #pdb.set_trace()
-
         oid = obj.get('id', None)
         if not oid:
             raise InterfaceError(f'Missing object id in: {obj}')
@@ -256,9 +273,14 @@ class Cursor:
         row_compiler = RowCompiler()
         desc_compiler = DescriptionCompiler()
         if object_ == 'page':
+            # IMPORTANT: Refactor cursor description in DBAPI.
+            # Pages are now compiled only by the row compiler.
+            # Description is injected by the ExecutionContext, because it is not
+            # inferred anymore using the description compiler.
+            # See issue: https://github.com/giant0791/normlite/issues/150
             page: NotionPage = parse_page(obj)
             row = page.compile(row_compiler)
-            self._description = page.compile(desc_compiler)
+            
         elif object_ == 'database':
             database: NotionDatabase = parse_database(obj)
             row = database.compile(row_compiler)

--- a/src/normlite/notiondbapi/dbapi2_consts.py
+++ b/src/normlite/notiondbapi/dbapi2_consts.py
@@ -39,6 +39,8 @@ class DBAPITypeCode(StrEnum):
     NUMBER_DOLLAR      = 'dollar'
     RICH_TEXT          = 'rich_text'
     DATE               = 'date'
+    ARCHIVAL_FLAG      = 'boolean'
+    TIMESTAMP          = 'string_iso_8601'
     META_COL_NAME      = 'column_name'
     META_COL_TYPE      = 'column_type'
     META_COL_ID        = 'column_id'

--- a/src/normlite/sql/base.py
+++ b/src/normlite/sql/base.py
@@ -25,6 +25,7 @@ import pdb
 from typing import Any, ClassVar, NoReturn, Optional, Protocol, TYPE_CHECKING, Self, Sequence, overload
 import copy
 
+from normlite._constants import SpecialColumns
 from normlite.engine.interfaces import _distill_params
 from normlite.exceptions import ArgumentError, UnsupportedCompilationError
 from normlite.utils import frozendict
@@ -134,10 +135,6 @@ class ClauseElement(Generative, Visitable):
             return DDLCompiled(self, compiled_dict, compiler)
         else:
             return Compiled(self, compiled_dict, compiler)
-
-    def get_table(self) -> Table:
-        """Return a collection of columns this clause element refers to."""
-        raise NotImplementedError
 
 class Executable(ClauseElement):
     """Provide the interface for all executable SQL statements.
@@ -350,10 +347,16 @@ class Compiled:
         self._execution_binds = dict(compiler._compiler_state.execution_binds)
         """The bind parameters for this compiled object."""
 
-        self._result_columns = compiler._compiler_state.result_columns
+        is_dml = not self.is_ddl
+        self._result_columns = [
+            colname
+            for colname in SpecialColumns.values(is_dml)
+        ]
         """Optional sequence of strings specifying the column names to be considered 
         in the rows produced by the :class:`normlite.cursor.CursorResult` methods.
         """
+        if compiler._compiler_state.result_columns is not None:
+            self._result_columns.extend(compiler._compiler_state.result_columns)
 
         self._compiler_state = compiler._compiler_state
 

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -377,7 +377,7 @@ class NotionCompiler(SQLCompiler):
             # create a mapping for all user columns with dummy values
             placeholders = {
                 col.name: 'placeholder_value'
-                for col in insert.table.get_user_defined_colums()
+                for col in insert.get_table().get_user_defined_colums()
             }
 
             insert = insert.values(**placeholders)
@@ -442,9 +442,11 @@ class NotionCompiler(SQLCompiler):
         payload = {
             'page_size': 100        # Notion imposed max page size
         }
-        database_id = select.table.get_oid()
+        
+        table = select.get_table()
+        database_id = table.get_oid()
         if database_id is None:
-            raise CompileError(f'Table: {select.table.name} has not been previously reflected.')
+            raise CompileError(f'Table: {table.name} has not been previously reflected.')
         
         with self._compiling(new_state=_CompileState.COMPILING_DBAPI_PARAM):
             db_id_key = self._add_bindparam(
@@ -463,21 +465,16 @@ class NotionCompiler(SQLCompiler):
                 payload['filter'] = filter_obj
 
         projection = self._compiler_state.stmt._projection
-        self._compiler_state.result_columns = [
-                col.name 
-                for col in select.table.c 
-                if col.name in SpecialColumns.values()
-        ]
 
         if projection:
             # use select projections for the result columns    
-            self._compiler_state.result_columns.extend(projection)
+            self._compiler_state.result_columns = list(projection)
             query_params['filter_properties'] = projection
         
         else:
             # the select statement provides no projections
             # add all user defined columns
-            user_cols = [col.name for col in select.table.get_user_defined_colums()]
+            user_cols = [col.name for col in table.get_user_defined_colums()]
             self._compiler_state.result_columns.extend(user_cols)
 
         if select._order_by.has_expression():

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -32,7 +32,19 @@ if TYPE_CHECKING:
     from normlite.engine.base import Connection
     from normlite.engine.context import ExecutionContext
 
-class ExecutableClauseElement(Executable):
+
+class HasTable(Protocol):
+    """Mixin for DML statements"""
+
+    def get_table(self) -> Table:
+        try:
+            return self._table
+        except AttributeError:
+            raise ArgumentError(
+                f"Class '{self.__class__.__name__}' shall have a '_table' attribute."
+            )
+
+class ExecutableClauseElement(HasTable, Executable):
     """Specialized executable for DML statements
     
     This class is the base of all DML constructs.
@@ -41,6 +53,9 @@ class ExecutableClauseElement(Executable):
     """
     
     is_ddl = False
+
+    _table: Table
+    """The table this executable is referred to."""
 
     def _execute_on_connection(
             self, 
@@ -72,7 +87,7 @@ class ValuesBase(ExecutableClauseElement):
     """The immutable mapping holding the values."""
 
     def __init__(self, table: Table):
-        self.table = table
+        self._table = table
         self._values = None
 
     @generative
@@ -127,7 +142,7 @@ class ValuesBase(ExecutableClauseElement):
         # Convert raw values → BindParameter
         for key, value in new_values.items():
             # structural validation
-            if key not in self.table.columns:
+            if key not in self.get_table().columns:
                 raise ArgumentError(f"Wrong key supplied: {key}")
 
             if isinstance(value, BindParameter):
@@ -192,19 +207,10 @@ class Insert(ValuesBase):
     def __init__(self, table: Table):
         super().__init__(table)
 
-        self._table: Table = table
-        """The table object to insert a new row to."""
-
         self._returning = ()
         """The tuple holding the Notion specific columns."""
 
-        for spec_col in SpecialColumns._member_names_:
-            self._returning += (spec_col, )
-
-    def _set_table(self, table: Table) -> None:
-        self._table = table
-
-    def get_table(self) -> ReadOnlyColumnCollection:
+    def get_table_columns(self) -> ReadOnlyColumnCollection:
         return self._table.columns
     
     def returning(self, *cols: Column) -> Self:
@@ -249,7 +255,7 @@ class Insert(ValuesBase):
     def __repr__(self):
         kwarg = []
         if self._table:
-            kwarg.append('table')
+            kwarg.append('_table')
 
         if self._values:
             kwarg.append('values')
@@ -331,7 +337,7 @@ class OrderByClause(HasExpression, ClauseElement):
     def has_expression(self) -> bool:
         return self.clauses
 
-class Select(ExecutableClauseElement):
+class Select(ExecutableClauseElement, HasTable):
     __visit_name__ = 'select'
     is_select = True
 
@@ -355,7 +361,7 @@ class Select(ExecutableClauseElement):
         if len(entities) == 1 and isinstance(entities[0], Table):
             # a Table object has been provided
             table = entities[0]
-            self.table = table
+            self._table = table
             self._projection = []  # project all columns
             return
 
@@ -376,14 +382,14 @@ class Select(ExecutableClauseElement):
                 "All selected columns must belong to the same table"
             )
 
-        self.table: Table = tables.pop()
+        self._table: Table = tables.pop()
         # --- SAFEGUARD: column names must exist on the table ---
-        table_columns = self.table.get_user_defined_colums()
+        table_columns = self._table.get_user_defined_colums()
 
         for col in columns:
             if col.name not in table_columns:
                 raise ArgumentError(
-                    f'Column: {col.name} does not belong to table: {self.table.name}'
+                    f'Column: {col.name} does not belong to table: {self._table.name}'
                 )
         self._projection = [col.name for col in columns]
 

--- a/src/normlite/sql/elements.py
+++ b/src/normlite/sql/elements.py
@@ -342,6 +342,9 @@ class NumberComparator(Comparator):
 class DateComparator(Comparator):
     pass
 
+class TimeStampStringISO8601Comparator(Comparator):
+    pass
+
 class _NoArg(Enum):
     NO_ARG = 0
 

--- a/src/normlite/sql/reflection.py
+++ b/src/normlite/sql/reflection.py
@@ -1,9 +1,27 @@
+# sql/reflection.py
+# Copyright (C) 2026 Gianmarco Antonini
+#
+# This module is part of normlite and is released under the GNU Affero General Public License.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 from __future__ import annotations
 import pdb
 from typing import Any, NamedTuple, Optional, Sequence
 from normlite._constants import SpecialColumns
 from normlite.notion_sdk.getters import get_title
-from normlite.sql.type_api import Boolean, ObjectId, String, TypeEngine, type_mapper
+from normlite.sql.type_api import Boolean, ObjectId, String, TimeStampStringISO8601, TypeEngine, type_mapper
 
 class ReflectedColumnInfo(NamedTuple):
     name: str
@@ -37,10 +55,10 @@ class ReflectedTableInfo:
         return self._columns[self._colmap[SpecialColumns.NO_IN_TRASH]].value
     
     def get_user_columns(self) -> Sequence[ReflectedColumnInfo]:
-        return [rc for rc in self._columns if rc.name not in SpecialColumns.values()]
+        return [rc for rc in self._columns if rc.name not in SpecialColumns.values(is_dml=False)]
     
     def get_sys_columns(self) -> Sequence[ReflectedColumnInfo]:
-        return [rc for rc in self._columns if rc.name in SpecialColumns.values()]
+        return [rc for rc in self._columns if rc.name in SpecialColumns.values(is_dml=False)]
         
     def get_columns(self) -> Sequence[ReflectedColumnInfo]:
         return self._columns
@@ -49,7 +67,7 @@ class ReflectedTableInfo:
         if include_all:
             return [rc.name for rc in self._columns]
         else:
-            return [rc.name for rc in self._columns if rc.name not in SpecialColumns.values()]
+            return [rc.name for rc in self._columns if rc.name not in SpecialColumns.values(is_dml=False)]
         
     @classmethod
     def from_tuples(cls, cols_as_tuples: Sequence[tuple]) -> ReflectedTableInfo:
@@ -112,6 +130,13 @@ class ReflectedTableInfo:
             type=Boolean(),
             id=None,
             value=database_obj['in_trash']
+        ))
+
+        cols.append(ReflectedColumnInfo(
+            name=SpecialColumns.NO_CREATED_TIME,
+            type=TimeStampStringISO8601(),
+            id=None,
+            value=database_obj['created_time']
         ))
 
         # reflect properties

--- a/src/normlite/sql/resultschema.py
+++ b/src/normlite/sql/resultschema.py
@@ -1,0 +1,121 @@
+# sql/resultschema.py
+# Copyright (C) 2026 Gianmarco Antonini
+#
+# This module is part of normlite and is released under the GNU Affero General Public License.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Provide logical result-set representation (coming from compiled SQL).
+
+.. note::
+    In this version, the schema for the result-set faithfully represent
+    **all** columns.
+    Currently supported Notion object properties are:
+
+    * "id" - string (UUIDv4), unique identifier of the page.
+    * "created_time" - Python datetime normalized string from ISO 8601 ("+Z" replaced by "+0:00"),
+      date and time when this page was created. 
+    * "last_edited_time" - Python datetime normalized string from ISO 8601 ("+Z" replaced by "+0:00"),
+      date and time when this page was updated. 
+    * "archived" - boolean, backward compatible alias for "in_trash".
+    * "in_trash" - boolean, whether the page has been trashed.
+
+.. versionadded:: 0.9.0
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Sequence
+
+from normlite.exceptions import NoSuchColumnError
+from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
+from normlite.sql.schema import Table
+
+@dataclass(frozen=True)
+class ResultColumn:
+    """Represent one column in the result set."""
+    name: str
+    type_code: DBAPITypeCode
+    nullable: bool
+
+@dataclass(frozen=True)
+class SchemaInfo:
+    """Represent all comuns in the result set (incl. special ones)."""
+    columns: Sequence[ResultColumn]
+
+    @classmethod
+    def from_table(
+        cls,
+        table: Table,
+        projected_names: Sequence[str],
+    ) -> SchemaInfo:
+        """Build schema information from a :class:`normlite.sql.schema.Table`.
+
+        The schema information **always** contains all columns: user defines **and** system columns.
+
+        Args:
+            table (Table): The table representive the authoritative source of the schema.
+            projected_names (Sequence[str]): The ordered projection list coming from :attr:`normlite.engine.context.ExecutionContext.compiled._result_columns`.
+
+        Raises:
+            NoSuchColumnError: If any of the column names in ``projection_names`` could not be found in the table.
+
+        Returns:
+            SchemaInfo: A new schema information instance.
+
+        .. versionadded:: 0.9.0
+        """
+        result_columns: list[ResultColumn] = []
+
+        for name in projected_names:
+
+            # Table-declared columns
+            try:
+                column = table.c[name]
+            except KeyError:
+                raise NoSuchColumnError(
+                    f"Column '{name}' not found in table "
+                    f"'{table.name}' or special column registry."
+                )
+
+            result_columns.append(
+                ResultColumn(
+                    name=name,
+                    type_code=column.type_.get_dbapi_type(),
+                    nullable=None,
+                )
+            )
+
+        return cls(tuple(result_columns))
+    
+    def as_sequence(self) -> Sequence[tuple]:
+        """Provide the description for DBAPI cursors.
+        
+        This method is the official API for :class:`SchemaInfo`.
+        """
+        entries = []
+
+        for col in self.columns:
+            entry = (
+                col.name,
+                col.type_code,      
+                None,                        # display_size
+                None,                        # internal_size
+                None,                        # precision
+                None,                        # scale
+                None,                        # col.nullable for future versions.
+            )
+
+            entries.append(entry)
+
+        return tuple(entries)

--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -66,7 +66,7 @@ from normlite.engine.systemcatalog import TableState
 from normlite.exceptions import ArgumentError, DuplicateColumnError, InvalidRequestError, NoSuchTableError
 from normlite.notiondbapi.dbapi2 import InternalError, ProgrammingError
 from normlite.sql.elements import ColumnElement, ColumnOperators
-from normlite.sql.type_api import ArchivalFlag, ObjectId, String, TypeEngine
+from normlite.sql.type_api import ArchivalFlag, ObjectId, String, TimeStampStringISO8601, TypeEngine
 
 if TYPE_CHECKING:
     from normlite.engine.base import Engine
@@ -584,6 +584,11 @@ class Table(HasIdentifier):
             _no_in_trash_col = Column(SpecialColumns.NO_IN_TRASH, ArchivalFlag())
             _no_in_trash_col._set_parent(self)
             self._columns.add(_no_in_trash_col)
+
+        if SpecialColumns.NO_CREATED_TIME not in self._columns:
+            _no_created_time_col = Column(SpecialColumns.NO_CREATED_TIME, TimeStampStringISO8601())
+            _no_created_time_col._set_parent(self)
+            self._columns.add(_no_created_time_col)
 
     def _create_pk_constraint(self) -> None:
         table_pks = [c for c in self._columns if c.primary_key]

--- a/src/normlite/sql/type_api.py
+++ b/src/normlite/sql/type_api.py
@@ -77,8 +77,9 @@ from types import MappingProxyType
 from typing import Any, Callable, List, Literal, NoReturn, Optional, Protocol, TypeAlias, Union, TYPE_CHECKING
 import uuid
 
+from normlite.exceptions import InvalidRequestError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
-from normlite.sql.elements import Operator, BooleanComparator, Comparator, NumberComparator, DateComparator, ObjectIdComparator, StringComparator
+from normlite.sql.elements import Operator, BooleanComparator, Comparator, NumberComparator, DateComparator, ObjectIdComparator, StringComparator, TimeStampStringISO8601Comparator
 
 
 class TypeEngine(Protocol):
@@ -134,6 +135,28 @@ class TypeEngine(Protocol):
         return {
             self.get_col_spec(): {}
         }
+    
+    @property
+    def python_type(self) -> Any:
+        """Return the Python type object expected to be returned
+        by instances of this type.
+
+        Basically, for those types which enforce a return type,
+        or are known across the board to do such for all common
+        DBAPIs (like ``int`` for example), will return that type.
+
+        By default the generic ``object`` type is returned.
+
+        Returns:
+            Any: The Python type corresponding to this type engine instance.
+
+        .. versionadded:: 0.9.0
+        """
+        return object
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        """ Return the DBAPI type code corresponding to this type engine instance."""
+        raise NotImplemented
 
     def __repr__(self):
         return self.__class__.__name__
@@ -238,6 +261,13 @@ class Integer(Number):
     def __init__(self):
         super().__init__('number')
 
+    @property
+    def python_type(self) -> Any:
+        return int
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.NUMBER
+
 class Numeric(Number):
     """Convenient type engine for Notion "number" objects with format ="number_with_commas".
     
@@ -247,6 +277,13 @@ class Numeric(Number):
     def __init__(self):
         super().__init__('number_with_commas')
 
+    @property
+    def python_type(self) -> Any:
+        return Decimal
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.NUMBER_WITH_COMMAS
+
 class Money(Number):
     """Convenient type engine for Notion "number" objects handling currencies.
     
@@ -254,6 +291,16 @@ class Money(Number):
     """
     def __init__(self, currency: Currency):
         super().__init__(currency)
+
+    @property
+    def python_type(self) -> Any:
+        return Decimal
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        if self.format == "dollar":
+            return DBAPITypeCode.NUMBER_DOLLAR
+        
+        raise NotImplementedError(f"Number format '{self.format}' not supported in this version.")
 
 class String(TypeEngine):
     """Textual type for Notion title and rich text properties.
@@ -325,6 +372,13 @@ class String(TypeEngine):
             ["%s=%s" % (k, repr(getattr(self, k))) for k in kwarg]
         )
     
+    @property
+    def python_type(self) -> Any:
+        return str
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.TITLE if self.is_title else DBAPITypeCode.RICH_TEXT
+
 class Boolean(TypeEngine):
     """Covenient type engine class for "checkbox" objects.
     
@@ -371,6 +425,13 @@ class Boolean(TypeEngine):
             )
         return process
     
+    @property
+    def python_type(self) -> Any:
+        return bool
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.CHECKBOX
+
 class Date(TypeEngine):
     """Convenient type engine class for "date" objects.
     
@@ -427,24 +488,26 @@ class Date(TypeEngine):
         return process
 
     def result_processor(self):
-        def process(value: Optional[dict]) -> Optional[Union[tuple, datetime]]:
+        def process(value: Optional[dict]) -> Optional[tuple[Optional[datetime], Optional[datetime]]]:
             if value is None:
                 return None
-            
-            self._raise_if_val_not_dict(value)
-            date_value = value.get('date')
 
-            start = datetime.fromisoformat(date_value["start"]) if date_value.get("start") else None
-            end = datetime.fromisoformat(date_value["end"]) if date_value.get("end") else None
-            restored = (start, end)
-        
-            if restored == (None, None):
+            self._raise_if_val_not_dict(value)
+            date_value = value.get("date")
+
+            if not date_value:
                 return None
-            
-            if restored[1] is None:
-                return restored[0]
-            
-            return restored
+
+            start_raw = date_value.get("start")
+            end_raw = date_value.get("end")
+
+            start = datetime.fromisoformat(start_raw) if start_raw else None
+            end = datetime.fromisoformat(end_raw) if end_raw else None
+
+            if start is None and end is None:
+                return None
+
+            return (start, end)
         return process
     
     def filter_value_processor(self):
@@ -467,19 +530,26 @@ class Date(TypeEngine):
     def get_col_spec(self):
         return "date"
 
+    @property
+    def python_type(self) -> Any:
+        return tuple
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.DATE
+
 class UUID(TypeEngine):
     """Base type engine class for UUID ids.
+
+    .. versionchanged:: 0.9.0
+        :meth:`bind_processor` raises :exc:`normlite.exceptions.InvalidRequestError`:
+        Object ids are in Notion **read-only** properties.
     
     .. versionadded:: 0.7.0
     """
     def bind_processor(self):
-        def process(value: Optional[Union[str, uuid.UUID]]) -> Optional[str]:
-            if value is None:
-                return None
-            if isinstance(value, uuid.UUID):
-                return str(value)   # JSON-safe
-            return str(uuid.UUID(value))      # parse from string
-        return process
+        raise InvalidRequestError(
+            "Cannot bind values to system-managed object/property id columns."
+        )
 
     def result_processor(self):
         def process(value: Optional[str]) -> Optional[str]:
@@ -491,6 +561,10 @@ class UUID(TypeEngine):
     def get_col_spec(self):
         return "UUID"
 
+    @property
+    def python_type(self) -> Any:
+        return str
+    
 class PropertyId(TypeEngine):
     """Type engine class for property identifiers.
     
@@ -500,11 +574,9 @@ class PropertyId(TypeEngine):
 
     """
     def bind_processor(self):
-        def process(value: Optional[str]) -> Optional[str]:
-            if value is None:
-                return None
-            return value   # JSON-safe
-        return process
+        raise InvalidRequestError(
+            "Cannot bind values to system-managed preperty 'id' columns."
+        )
 
     def result_processor(self):
         def process(value: Optional[str]) -> Optional[str]:
@@ -514,7 +586,10 @@ class PropertyId(TypeEngine):
         return process
 
     def get_col_spec(self):
-        return "id"
+        raise NotImplementedError('Column spec is not supported for this type engine subclass.')
+  
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.PROPERTY_ID
 
 class ObjectId(UUID):
     """Special UUID type representing Notion's "id" property.
@@ -524,18 +599,24 @@ class ObjectId(UUID):
     comparator_factory = ObjectIdComparator
 
     def get_col_spec(self):
-        return "id"
+        raise NotImplementedError('Column spec is not supported for this type engine subclass.')
+  
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.ID
 
 class ArchivalFlag(Boolean):
-    """Special Boolean type representing Notion's "archived" property.
+    """Special Boolean type representing Notion "in_trash" and "archived" keys.
+
+    .. versionchanged:: 0.9.0
+        This version support provision of the DBAPI type code for full integration into result-set
+        schema information.
     
     .. versionadded:: 0.7.0
     """
 
     def get_col_spec(self):
-        # In Notion JSON, this is always stored under property 'archived'
-        return "archived"
-
+        raise NotImplementedError('Column spec is not supported for this type engine subclass.')
+    
     def bind_processor(self):
         def process(value: Optional[bool]) -> Optional[bool]:
             if value is None:
@@ -549,6 +630,57 @@ class ArchivalFlag(Boolean):
                 return None
             return bool(value)
         return process
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.ARCHIVAL_FLAG
+
+class TimeStampStringISO8601(TypeEngine):
+    """Special type representing Notion "created_time" and "last_edited_time" keys.
+    
+    .. versionadded:: 0.9.0
+    """
+
+    comparator_factory = TimeStampStringISO8601Comparator
+
+    def get_col_spec(self):
+        raise NotImplementedError('Column spec is not supported for this type engine subclass.')
+    
+    def _validate_iso8601(self, value: str) -> None:
+        """Validate ISO 8601 compatibility."""
+        try:
+            normalized = value.replace("Z", "+00:00")
+            datetime.fromisoformat(normalized)
+        except Exception as exc:
+            raise ValueError(
+                f"Value '{value}' is not a valid ISO 8601 timestamp."
+            ) from exc
+
+    def bind_processor(self):
+        raise InvalidRequestError(
+            "Cannot bind values to system-managed timestamp columns."
+        )
+
+    def result_processor(self):
+        def process(value: Optional[str]) -> Optional[str]:
+            if value is None:
+                return None
+
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Expected ISO 8601 string from Notion, got {type(value).__name__}"
+                )
+
+            self._validate_iso8601(value)
+            return value
+        
+        return process
+
+    @property
+    def python_type(self) -> Any:
+        return str
+    
+    def get_dbapi_type(self) -> DBAPITypeCode:
+        return DBAPITypeCode.TIMESTAMP
 
 type_mapper: dict[str, TypeEngine] = {
     DBAPITypeCode.ID: ObjectId(),
@@ -559,5 +691,7 @@ type_mapper: dict[str, TypeEngine] = {
     DBAPITypeCode.NUMBER: Integer(),
     DBAPITypeCode.NUMBER_WITH_COMMAS: Numeric(),
     DBAPITypeCode.NUMBER_DOLLAR: Money('dollar'),
-    DBAPITypeCode.DATE: Date()
+    DBAPITypeCode.DATE: Date(),
+    DBAPITypeCode.ARCHIVAL_FLAG: ArchivalFlag(),
+    DBAPITypeCode.TIMESTAMP: TimeStampStringISO8601(),
 }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -281,6 +281,47 @@ def test_execute_dml_context_returning(
     assert students.c.name.name in mapping
     assert students.c.id.name in mapping
     assert not students.c.is_active.name in mapping
+    assert students.c._no_created_time.name in mapping
+
+def test_execute_dml_context_returning_correct_dbapi_description(
+    engine: Engine, 
+    students: Table, 
+    insert_values: dict
+):
+    # create database and mock reflection
+    database_id = create_students_db(engine)
+    students.set_oid(database_id)
+    insert_stmt = insert(students).returning(students.c.name, students.c.id)
+    # Connection.execute(insert_stmt, insert_values)
+    distilled_params = _distill_params(insert_values)
+
+    # stmt._execute_on_connection(connection, distilled_params, execution_options)
+    compiled = insert_stmt.compile(engine._sql_compiler)
+    cursor = engine.raw_connection().cursor()
+    ctx = ExecutionContext(
+        engine,
+        engine.connect(),
+        cursor=cursor,
+        compiled=compiled,
+        distilled_params=distilled_params,
+    )
+
+    # Connection._execute_context(context) -> CursorResult:
+    #pdb.set_trace()
+    ctx.pre_exec()
+    engine.do_execute(cursor, ctx.operation, ctx.parameters)
+    ctx.post_exec()
+ 
+    # extract cursor.description
+    description = cursor.description
+    col_names = [name for name, _, _, _, _, _, _ in cursor.description]
+
+    assert len(description) == 6
+    assert '_no_id' in col_names
+    assert '_no_in_trash' in col_names
+    assert '_no_archived' in col_names
+    assert '_no_created_time' in col_names
+    assert '_no_parent_id' not in col_names
 
 @pytest.mark.parametrize("preserve_rowcount,expected_rowcount", [
         (True, 2),

--- a/tests/test_dbapi2_cursor.py
+++ b/tests/test_dbapi2_cursor.py
@@ -3,6 +3,22 @@ import uuid
 
 import pytest
 from normlite.notiondbapi.dbapi2 import Cursor, Error, InterfaceError
+from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
+from normlite.sql.resultschema import ResultColumn, SchemaInfo
+
+@pytest.fixture
+def students_schema() -> SchemaInfo:
+    return SchemaInfo(
+        columns=[
+            ResultColumn(name="_no_id", type_code=DBAPITypeCode.ID, nullable=False),
+            ResultColumn(name="_no_archived", type_code=DBAPITypeCode.ARCHIVAL_FLAG, nullable=False),
+            ResultColumn(name="_no_in_trash", type_code=DBAPITypeCode.ARCHIVAL_FLAG, nullable=False),
+            ResultColumn(name="_no_created_time", type_code=DBAPITypeCode.TIMESTAMP, nullable=False),
+            ResultColumn(name="id", type_code=DBAPITypeCode.NUMBER, nullable=False),
+            ResultColumn(name="grade", type_code=DBAPITypeCode.RICH_TEXT, nullable=False),
+            ResultColumn(name="name", type_code=DBAPITypeCode.TITLE, nullable=False),
+        ]
+    ) 
 
 def make_result_set(dbapi_cursor: Cursor) -> Cursor:
     dbapi_cursor._parse_result_set({
@@ -32,7 +48,6 @@ def make_result_set(dbapi_cursor: Cursor) -> Cursor:
             },
         ]
     }) 
-
 
 def test_rowcount_result_set_not_empty(dbapi_cursor: Cursor):
     # Given: 

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -2,11 +2,13 @@ from datetime import date
 import uuid
 import pytest
 
+from normlite._constants import SpecialColumns
 from normlite.exceptions import CompileError
 from normlite.sql.base import _CompileState, CompilerState
 from normlite.sql.compiler import NotionCompiler
 from normlite.sql.dml import ValuesBase, insert
 from normlite.sql.elements import _BindRole, BindParameter
+from normlite.sql.resultschema import SchemaInfo
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import Boolean, Date, Integer, String
 
@@ -199,5 +201,32 @@ def test_bindparam_column_name_not_found_error(students: Table):
         nc._compiler_state.stmt = insert(students)
         nc._add_bindparam(bp, column_name='another_fake')
 
+#---------------------------------------------
+# SchemaInfo tests
+#---------------------------------------------
 
+def test_schema_info_created_from_table_all_cols(students: Table):
+    projected_cols = [c.name for c in students.columns]
+    schema = SchemaInfo.from_table(students, projected_cols)
 
+    assert len(schema.columns) == 9
+
+def test_schema_info_created_from_table_all_sys_cols(students: Table):
+    projected_cols = [c.name for c in students.columns if c.name in SpecialColumns.values()]
+    schema = SchemaInfo.from_table(students, projected_cols)
+    schema_col_names = [c.name for c in schema.columns]
+
+    assert "_no_id" in schema_col_names
+    assert "_no_archived" in schema_col_names
+    assert "_no_in_trash" in schema_col_names
+    assert "_no_created_time" in schema_col_names
+    assert len(schema.columns) == 4
+
+def test_schema_info_created_from_table_projected_cols(students: Table):
+    projected_cols = ["id", "name"]
+    schema = SchemaInfo.from_table(students, projected_cols)
+    schema_col_names = [c.name for c in schema.columns]
+
+    assert len(schema.columns) == 2
+    assert "id" in schema_col_names
+    assert "name" in schema_col_names


### PR DESCRIPTION
…class ([#150](https://github.com/giant0791/normlite/issues/150)).

This version brings a host of changes around the redesigned description: It is not inferred, it comes from the authoritative source `Table` object.

Closes #150.