### PR TITLE
feat(sql): Add filter for non deleted pages only in `NotionCompiler.v…

### DIFF
--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -269,7 +269,7 @@ class NotionCompiler(SQLCompiler):
 
         # emit code for properties object
         payload['properties'] = self._compile_table_columns(
-            stmt_table.get_user_defined_colums()
+            stmt_table.columns
         )
         
         self._compiler_state.result_columns = [
@@ -377,7 +377,7 @@ class NotionCompiler(SQLCompiler):
             # create a mapping for all user columns with dummy values
             placeholders = {
                 col.name: 'placeholder_value'
-                for col in insert.get_table().get_user_defined_colums()
+                for col in insert.get_table().columns
             }
 
             insert = insert.values(**placeholders)
@@ -435,12 +435,14 @@ class NotionCompiler(SQLCompiler):
     def visit_select(self, select: Select) -> dict:
         self._compiler_state.is_select = select.is_select
         self._compiler_state.stmt = select
+        self._compiler_state.result_columns = list()
 
         operation = dict(endpoint='databases', request='query')
         path_params = {}
         query_params = {}
         payload = {
-            'page_size': 100        # Notion imposed max page size
+            'page_size': 100,        # Notion imposed max page size
+            'in_trash': False,       # Always return non deleted pages only
         }
         
         table = select.get_table()
@@ -468,13 +470,13 @@ class NotionCompiler(SQLCompiler):
 
         if projection:
             # use select projections for the result columns    
-            self._compiler_state.result_columns = list(projection)
+            self._compiler_state.result_columns.extend(projection)
             query_params['filter_properties'] = projection
         
         else:
             # the select statement provides no projections
             # add all user defined columns
-            user_cols = [col.name for col in table.get_user_defined_colums()]
+            user_cols = [col.name for col in table.columns]
             self._compiler_state.result_columns.extend(user_cols)
 
         if select._order_by.has_expression():
@@ -629,7 +631,7 @@ class NotionCompiler(SQLCompiler):
     def _compile_insert_update_values(self, values: dict) -> dict:
         properties = {}
         stmt_table = self._compiler_state.stmt._table
-        user_cols = stmt_table.get_user_defined_colums()
+        user_cols = stmt_table.columns
         if len(user_cols) != len(values):
             raise CompileError(
                 'Not enough values supplied for all user defined columns '

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -384,7 +384,7 @@ class Select(ExecutableClauseElement, HasTable):
 
         self._table: Table = tables.pop()
         # --- SAFEGUARD: column names must exist on the table ---
-        table_columns = self._table.get_user_defined_colums()
+        table_columns = self._table.columns
 
         for col in columns:
             if col.name not in table_columns:

--- a/src/normlite/sql/reflection.py
+++ b/src/normlite/sql/reflection.py
@@ -61,13 +61,11 @@ class ReflectedTableInfo:
     def in_trash(self) -> Optional[True]:
         return self._columns[self._colmap[SpecialColumns.NO_IN_TRASH]].value
     
-    @normlite_deprecated("This method is deprecated and will be removed in a future version.")
     def get_user_columns(self) -> Sequence[ReflectedColumnInfo]:
-        return [rc for rc in self._columns if rc.name not in SpecialColumns.values()]
+        return [rc for rc in self._columns if not rc.is_system]
     
-    @normlite_deprecated("This method is deprecated and will be removed in a future version.")
     def get_sys_columns(self) -> Sequence[ReflectedColumnInfo]:
-        return [rc for rc in self._columns if rc.name in SpecialColumns.values()]
+        return [rc for rc in self._columns if rc.is_system]
         
     def get_columns(self) -> Sequence[ReflectedColumnInfo]:
         return self._columns
@@ -77,7 +75,7 @@ class ReflectedTableInfo:
         if include_all:
             return [rc.name for rc in self._columns]
         else:
-            return [rc.name for rc in self._columns if rc.name not in SpecialColumns.values()]
+            return [rc.name for rc in self._columns if not rc.is_system]
         
     @classmethod
     def from_tuples(cls, cols_as_tuples: Sequence[tuple]) -> ReflectedTableInfo:

--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -513,7 +513,7 @@ class Table(HasIdentifier):
     
     @normlite_deprecated("This method is deprecated and will be removed in a future version.")
     def set_oid(self, id_: str) -> None:
-        self._database_id = id_
+        self._sys_columns["object_id"]._value = id_
     
     def add_constraint(self, constraint: Constraint) -> None:
         """Add a constraint to this table."""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -33,7 +33,7 @@ def students(metadata: MetaData, mocked_db_id: str) -> Table:
         Column('start_on', Date()),
         Column('grade',  String())
     )
-    students.set_oid(mocked_db_id)      # ensure table is in reflected state
+    students._sys_columns["object_id"]._value = mocked_db_id      # ensure table is in reflected state
     return students
 
 @pytest.fixture
@@ -251,7 +251,7 @@ def test_execute_dml_context_row_preservation(
 ):
     # create database and mock reflection
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
     insert_stmt = insert(students)
 
     # Connection.execute(insert_stmt, insert_values)
@@ -281,10 +281,10 @@ def test_execute_dml_context_row_preservation(
     assert students.c.name.name not in mapping
     assert students.c.id.name not in mapping
     assert students.c.is_active.name not in mapping
-    assert students.c["_no_id"].name in mapping
-    assert students.c["_no_archived"].name in mapping
-    assert students.c["_no_in_trash"].name in mapping
-    assert students.c["_no_created_time"].name in mapping
+    assert students._sys_columns["object_id"].name in mapping
+    assert students._sys_columns["is_archived"].name in mapping
+    assert students._sys_columns["is_deleted"].name in mapping
+    assert students._sys_columns["created_at"].name in mapping
 
 @pytest.mark.skip(".returning requires new feature (see issue #200)")
 def test_execute_dml_context_returning(
@@ -377,7 +377,7 @@ def test_execute_dml_context_projection(
 ):
     # create database and mock reflection
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
 
     # add rows
     inserted_ids = add_students_rows(engine, students)
@@ -486,7 +486,7 @@ def test_execute_ddl_context_create_table_returning_property_ids(engine: Engine,
 
 def test_execute_ddl_context_drop_table_returning_id_and_in_trash(engine: Engine, students: Table):
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     cursor = engine.raw_connection().cursor()
@@ -545,7 +545,7 @@ def test_connection_exec_pipeline_simulated(engine: Engine, students: Table):
     assert result.rowcount == -1
     assert is_valid_uuid4(students.get_oid())
 
-    name_col, id_col, is_active_col, start_on_col, grade_col = students.get_user_defined_colums()
+    name_col, id_col, is_active_col, start_on_col, grade_col = students.columns
     assert name_col._id 
     assert id_col._id
     assert is_active_col._id
@@ -568,7 +568,7 @@ def test_connection_exec_dml_context_row_preservation(
 ):
     # create database and mock reflection
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
     insert_stmt = insert(students)
 
     with engine.connect() as connection:
@@ -598,7 +598,7 @@ def test_connection_exec_dml_context_returning(
 ):
     # create database and mock reflection
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
     insert_stmt = insert(students).returning(students.c.name, students.c.id)
 
     with engine.connect() as connection:
@@ -632,7 +632,7 @@ def test_connection_exec_dml_context_projection(
 ):
     # create database and mock reflection
     database_id = create_students_db(engine)
-    students.set_oid(database_id)
+    students._sys_columns["object_id"]._value = database_id
 
     # add rows
     inserted_ids = add_students_rows(engine, students)
@@ -684,7 +684,7 @@ def test_connection_exec_ddl_context_create_table(engine: Engine, students: Tabl
     assert result.rowcount == -1
     assert is_valid_uuid4(students.get_oid())
     assert all(
-        [c._id is not None for c in students.get_user_defined_colums()]
+        [c._id is not None for c in students.columns]
     )
 
 def test_connection_exec_ddl_context_drop_table(engine: Engine, students: Table):

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -111,7 +111,7 @@ def test_compile_create_table_columns_as_properties(students: Table, engine: Eng
 #---------------------------------------------
 
 def test_compile_drop_table_is_ddl(students: Table, engine: Engine):
-    students.set_oid('12345678-9090-0606-1111-123456789012')
+    students._sys_columns["object_id"]._value = "12345678-9090-0606-1111-123456789012"
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
 
@@ -119,7 +119,7 @@ def test_compile_drop_table_is_ddl(students: Table, engine: Engine):
     assert isinstance(compiled, DDLCompiled)
 
 def test_compile_drop_table_database_id(students: Table, engine: Engine):
-    students.set_oid('12345678-9090-0606-1111-123456789012')
+    students._sys_columns["object_id"]._value = "12345678-9090-0606-1111-123456789012"
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()
@@ -130,7 +130,7 @@ def test_compile_drop_table_database_id(students: Table, engine: Engine):
     db_id_param: BindParameter = compiled.params['database_id']
     assert db_id_param.type_ is None
     assert db_id_param.role == _BindRole.DBAPI_PARAM
-    assert db_id_param.effective_value == students._database_id
+    assert db_id_param.effective_value == students.get_oid()
     assert path_params['database_id'] == ':database_id'
 
 def test_compile_drop_table_no_database_id_raises(students: Table, engine: Engine):
@@ -140,7 +140,7 @@ def test_compile_drop_table_no_database_id_raises(students: Table, engine: Engin
         _ = stmt.compile(engine._sql_compiler)
         
 def test_compile_drop_table_operation(students: Table, engine: Engine):
-    students.set_oid('12345678-9090-0606-1111-123456789012')
+    students._sys_columns["object_id"]._value = "12345678-9090-0606-1111-123456789012"
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()
@@ -149,7 +149,7 @@ def test_compile_drop_table_operation(students: Table, engine: Engine):
     assert as_dict['operation']['request'] == 'update'
 
 def test_compile_drop_table_payload(students: Table, engine: Engine):
-    students.set_oid('12345678-9090-0606-1111-123456789012')
+    students._sys_columns["object_id"]._value = "12345678-9090-0606-1111-123456789012"
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()
@@ -185,7 +185,7 @@ def test_compile_reflect_table_database_id(students: Table, engine: Engine):
     db_id_param: BindParameter = compiled.params['database_id']
     assert db_id_param.type_ is None
     assert db_id_param.role == _BindRole.DBAPI_PARAM
-    assert db_id_param.effective_value == students._database_id
+    assert db_id_param.effective_value == students.get_oid()
     assert path_params['database_id'] == ':database_id'
 
 def test_compile_reflect_table_no_database_id_does_not_raise(students: Table, engine: Engine):

--- a/tests/test_dml.py
+++ b/tests/test_dml.py
@@ -272,6 +272,7 @@ def test_compile_binexp_number_operators():
     students = Table(
         'students', 
         metadata, 
+        Column("name", String(is_title=True)),
         Column('id', Integer()),
         Column('rate', Money(currency='dollar')),
         Column('grade', Numeric())    
@@ -299,7 +300,7 @@ def test_compile_binexp_number_operators():
 
 def test_compile_binexp_date_before():
     metadata = MetaData()
-    students = Table('students', metadata, Column('start_date', Date()))
+    students = Table('students', metadata, Column('start_date', Date()), Column("name", String(is_title=True)))
     exp: BinaryExpression = students.c.start_date.before(date.today)
     nc = NotionCompiler()
     nc._compiler_state = CompilerState()
@@ -311,7 +312,7 @@ def test_compile_binexp_date_before():
 
 def test_compile_binexp_date_after():
     metadata = MetaData()
-    students = Table('students', metadata, Column('start_date', Date()))
+    students = Table('students', metadata, Column('start_date', Date()), Column("name", String(is_title=True)))
     exp: BinaryExpression = students.c.start_date.after(date.today)
     nc = NotionCompiler()
     nc._compiler_state = CompilerState()
@@ -323,7 +324,7 @@ def test_compile_binexp_date_after():
 
 def test_compile_binexp_bool_opertors():
     metadata = MetaData()
-    students = Table('students', metadata, Column('is_active', Boolean()))
+    students = Table('students', metadata, Column('is_active', Boolean()), Column("name", String(is_title=True)))
     e1: BinaryExpression = students.c.is_active == True
     e2: BinaryExpression = students.c.is_active != True
     e3: BinaryExpression = students.c.is_active.is_(True)
@@ -347,7 +348,7 @@ def test_compile_binexp_bool_opertors():
 
 def test_compile_binexp_bool_forbid_truthiness():
     metadata = MetaData()
-    students = Table('students', metadata, Column('is_active', Boolean()))
+    students = Table('students', metadata, Column('is_active', Boolean()), Column("name", String(is_title=True)))
 
     with pytest.raises(TypeError, match='Use explicit comparison.'):
        if students.c.is_active:
@@ -355,20 +356,26 @@ def test_compile_binexp_bool_forbid_truthiness():
 
 def test_compile_select():
     metadata = MetaData()
-    students = Table('students', metadata, Column('start_date', Date()))
+    students = Table(
+        'students', 
+        metadata, 
+        Column('name', String(is_title=True)),
+        Column('start_date', Date())
+    )
     # monkey patch the id to simulate reflection
     database_id = str(uuid.uuid4())
-    students.set_oid(database_id)
+    students._sys_columns['object_id']._value = database_id
     stmt = select(students)
     sql_compiler = NotionCompiler()
     compiled = stmt.compile(sql_compiler)
     as_dict = compiled.as_dict()
     assert as_dict['operation']['request'] == 'query'
     assert as_dict['path_params']['database_id'] == ':database_id'
+    assert as_dict['payload']['in_trash'] == False
 
 def test_compile_select_w_where():
     metadata = MetaData()
-    students = Table('students', metadata, Column('start_date', Date()))
+    students = Table('students', metadata, Column('start_date', Date()), Column("name", String(is_title=True)))
     # monkey patch the id to simulate reflection
     database_id = str(uuid.uuid4())
     students.set_oid(database_id)

--- a/tests/test_drop_table.py
+++ b/tests/test_drop_table.py
@@ -38,7 +38,7 @@ def engine() -> Engine:
 
 def test_compile_drop_table_is_ddl(students: Table, engine: Engine):
     fake_db_id = str(uuid.uuid4())
-    students._database_id = fake_db_id
+    students._sys_columns["object_id"]._value = fake_db_id
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
 
@@ -47,7 +47,7 @@ def test_compile_drop_table_is_ddl(students: Table, engine: Engine):
 
 def test_compile_drop_table_database_id(students: Table, engine: Engine):
     fake_db_id = str(uuid.uuid4())
-    students._database_id = fake_db_id
+    students._sys_columns["object_id"]._value = fake_db_id
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()
@@ -58,7 +58,7 @@ def test_compile_drop_table_database_id(students: Table, engine: Engine):
     db_id_param: BindParameter = compiled.params['database_id']
     assert db_id_param.type_ is None
     assert db_id_param.role == _BindRole.DBAPI_PARAM
-    assert db_id_param.effective_value == students._database_id
+    assert db_id_param.effective_value == students.get_oid()
     assert path_params['database_id'] == ':database_id'
 
 def test_compile_drop_table_no_database_id_raises(students: Table, engine: Engine):
@@ -69,7 +69,7 @@ def test_compile_drop_table_no_database_id_raises(students: Table, engine: Engin
         
 def test_compile_drop_table_operation(students: Table, engine: Engine):
     fake_db_id = str(uuid.uuid4())
-    students._database_id = fake_db_id
+    students._sys_columns["object_id"]._value = fake_db_id
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()
@@ -79,7 +79,7 @@ def test_compile_drop_table_operation(students: Table, engine: Engine):
 
 def test_compile_drop_table_payload(students: Table, engine: Engine):
     fake_db_id = str(uuid.uuid4())
-    students._database_id = fake_db_id
+    students._sys_columns["object_id"]._value = fake_db_id
     stmt = DropTable(students)
     compiled = stmt.compile(engine._sql_compiler)
     as_dict = compiled.as_dict()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -204,7 +204,7 @@ def test_engine_inspector_reflect_sys_table(engine: Engine, inspector: Inspector
     #pdb.set_trace()
     inspector.reflect_table(tables)
 
-    assert tables._database_id == engine._tables_id
+    assert tables._sys_columns["object_id"]._value == engine._tables_id
     assert 'table_name' in tables.c
     assert 'table_schema' in tables.c
     assert 'table_catalog' in tables.c

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -60,7 +60,7 @@ def test_values_is_generative(students: Table):
 
 def test_compiler_dbapi_param_correctness(students: Table, insert_values: dict):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = insert(students).values(**insert_values)
 
     nc = NotionCompiler()
@@ -99,7 +99,7 @@ def test_compiler_correctness(students: Table, insert_values: dict):
 def test_compiler_generates_parent_id_as_bindparams(students: Table):
     """Does the compiler generates bind parameters for the payload?"""
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = insert(students).values(
         name = 'Galileo Galilei',
         id=123456,
@@ -120,7 +120,7 @@ def test_compiler_generates_values_as_bindparams(students: Table, insert_values:
     """Does the compiler generates bind parameters for the Insert.values()?"""
     nc = NotionCompiler()
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = insert(students).values(**insert_values)
 
     compiled = stmt.compile(nc)
@@ -140,7 +140,7 @@ def test_compiler_generates_values_as_bindparams(students: Table, insert_values:
 def test_compiler_detects_missing_values(students: Table, insert_values: dict):        
     nc = NotionCompiler()
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = insert(students)
     stmt.values(**insert_values)
 
@@ -211,7 +211,7 @@ def test_bindparam_column_name_not_found_error(students: Table):
 #---------------------------------------------
 
 def test_schema_info_created_from_table_all_cols(students: Table):
-    projected_cols = [c.name for c in students.get_user_defined_colums()]
+    projected_cols = [c.name for c in students.columns]
     schema = SchemaInfo.from_table(students, projected_cols)
 
     assert len(schema.columns) == 9        # 5 (usercols) + 4 (syscols)
@@ -221,10 +221,10 @@ def test_schema_info_created_from_table_all_sys_cols(students: Table):
     schema = SchemaInfo.from_table(students, projected_cols)
     schema_col_names = [c.name for c in schema.columns]
 
-    assert "_no_id" in schema_col_names
-    assert "_no_archived" in schema_col_names
-    assert "_no_in_trash" in schema_col_names
-    assert "_no_created_time" in schema_col_names
+    assert "object_id" in schema_col_names
+    assert "is_archived" in schema_col_names
+    assert "is_deleted" in schema_col_names
+    assert "created_at" in schema_col_names
     assert len(schema.columns) == 4
 
 def test_schema_info_created_from_table_projected_cols(students: Table):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -111,7 +111,7 @@ def test_bool_col_expr(students: Table):
 #---------------------------------------------
 def test_select_generate_operation(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
 
     stmt = (
         select_stmt
@@ -130,7 +130,7 @@ def test_select_generate_operation(students: Table, select_stmt: Select):
 #---------------------------------------------
 def test_where_generative_one_clause(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
 
     stmt = (
         select_stmt
@@ -154,7 +154,7 @@ def test_where_generative_one_clause(students: Table, select_stmt: Select):
 
 def test_where_generative_multi_clause(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
 
     stmt = (
         select_stmt
@@ -195,7 +195,7 @@ def test_where_generative_multi_clause(students: Table, select_stmt: Select):
 #---------------------------------------------
 def test_columns_subset_projection(students: Table):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt: Select = select(students.c.name, students.c.id, students.c.is_active)
 
     nc = NotionCompiler()
@@ -206,7 +206,7 @@ def test_columns_subset_projection(students: Table):
 
 def test_columns_all_projection(students: Table):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt: Select = select(students)
 
     nc = NotionCompiler()
@@ -217,16 +217,17 @@ def test_columns_all_projection(students: Table):
     assert 'query_params' not in asdict
 
     # there is only 1 key ==> this is the page_size
-    assert len(asdict['payload']) == 1  
+    assert len(asdict['payload']) == 2  
     assert 'page_size' in asdict['payload']
     assert asdict['payload']['page_size'] == 100
+    assert asdict["payload"]["in_trash"] == False
 
 #---------------------------------------------
 # ORDER BY tests
 #---------------------------------------------
 def test_order_by_generative_one_clause(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = (
         select_stmt
         .where(students.c.is_active.is_(True))
@@ -244,7 +245,7 @@ def test_order_by_generative_one_clause(students: Table, select_stmt: Select):
 
 def test_order_by_generative_multi_clauses(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt = (
         select_stmt
         .where(students.c.is_active.is_(True))
@@ -268,7 +269,7 @@ def test_order_by_generative_multi_clauses(students: Table, select_stmt: Select)
 #---------------------------------------------
 def test_full_select(students: Table):
     mocked_db_id = str(uuid.uuid4())
-    students.set_oid(mocked_db_id)
+    students._sys_columns["object_id"]._value = mocked_db_id
     stmt_base = select(students.c.id, students.c.name)
     stmt = (
         stmt_base


### PR DESCRIPTION
…isit_select()` ([#208](https://github.com/giant0791/normlite/issues/208)).

This version adds the filter for retrieving non-deleted pages only in the Notion compiler for the SELECT statement. All affected test scripts have been updated to run without deprecation warnings. Tests pass.

Closes #208.