### PR TITLE
feat(sql): Add `Delete` class and its compilation.

### DIFF
--- a/src/normlite/sql/base.py
+++ b/src/normlite/sql/base.py
@@ -25,15 +25,12 @@ import pdb
 from typing import Any, ClassVar, NoReturn, Optional, Protocol, TYPE_CHECKING, Self, Sequence, overload
 import copy
 
-from normlite._constants import SpecialColumns
-from normlite.engine.interfaces import _distill_params
 from normlite.exceptions import ArgumentError, UnsupportedCompilationError
 from normlite.utils import frozendict
 
 if TYPE_CHECKING:
-    from normlite.sql.schema import Table
     from normlite.sql.ddl import CreateTable, DropTable, ReflectTable
-    from normlite.sql.dml import Insert, Select
+    from normlite.sql.dml import Insert, Select, Delete
     from normlite.sql.elements import ColumnElement, UnaryExpression, BinaryExpression, BindParameter, BooleanClauseList
     from normlite.engine.cursor import CursorResult
     from normlite.engine.interfaces import _CoreAnyExecuteParams, ExecutionOptions, ReturningStrategy
@@ -153,16 +150,22 @@ class Executable(ClauseElement):
         This base class fully supports the connection-driven execution flow of SQL statements.
     """
 
-    supports_execution: bool = True
+    supports_execution: ClassVar[bool] = True
     """Structural flag denoting the main characteristic for an executable of supporting execution.
     
     .. versionadded:: 0.8.0
     """
 
-    is_ddl: bool = False
+    is_ddl: ClassVar[bool] = False
     """``True`` if the executable subclass is a DDL statement.
     
     .. versionadded:: 0.8.0
+    """
+
+    is_delete: ClassVar[bool] = False
+    """``True`` if executable is a DELETE statement.
+    
+    .. versionadded:: 0.9.0
     """
 
     _execution_options: Optional[ExecutionOptions] = None
@@ -433,6 +436,9 @@ class SQLCompiler(Protocol):
         ...
 
     def visit_select(self, select: Select) -> dict:
+        ...
+
+    def visit_delete(self, delete: Delete) -> dict:
         ...
 
     def visit_column_element(self, column: ColumnElement) -> dict:

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -25,7 +25,7 @@ from normlite._constants import SpecialColumns
 from normlite.exceptions import CompileError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
 from normlite.sql.base import _CompileState, SQLCompiler
-from normlite.sql.dml import OrderByClause
+from normlite.sql.dml import Delete, OrderByClause
 from normlite.sql.elements import _BindRole, BooleanClauseList, Operator, OrderByExpression, ColumnElement
 from normlite.sql.elements import BindParameter
 from normlite.sql.schema import ReadOnlyColumnCollection
@@ -491,6 +491,48 @@ class NotionCompiler(SQLCompiler):
 
         if query_params:           
             compiled_dict['query_params'] = query_params
+
+        return compiled_dict
+    
+    def visit_delete(self, delete: Delete):
+        self._compiler_state.is_delete = delete.is_delete
+        self._compiler_state.stmt = delete
+        self._compiler_state.result_columns = list()
+ 
+        operation = dict(endpoint='databases', request='query')
+        path_params = {}
+        query_params = {}
+        payload = {
+            'page_size': 100,        # Notion imposed max page size
+            'in_trash': False,       # Always return non deleted pages only
+        }
+ 
+        table = delete.get_table()
+        database_id = table.get_oid()
+        if database_id is None:
+            raise CompileError(f'Table: {table.name} has not been previously reflected.')
+
+        with self._compiling(new_state=_CompileState.COMPILING_DBAPI_PARAM):
+            db_id_key = self._add_bindparam(
+                BindParameter(
+                    key='database_id',
+                    value=database_id
+                )
+            )
+            path_params['database_id'] = f':{db_id_key}'
+
+        if delete._whereclause.has_expression():
+            with self._compiling(new_state=_CompileState.COMPILING_WHERE):
+                # emit the JSON code for the filter object of the query
+                # in the right context
+                filter_obj = delete._whereclause.expression._compiler_dispatch(self)
+                payload['filter'] = filter_obj
+
+        compiled_dict = {
+            'operation': operation, 
+            'path_params': path_params, 
+            'payload': payload
+        }
 
         return compiled_dict
 

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -423,3 +423,23 @@ def select(*entities: Union[Table, Column]) -> Select:
     return Select(*entities)
         
 
+class Delete(ExecutableClauseElement, HasTable):
+    """Represent a SQL DELETE statement."""
+
+    __visit_name__ = "delete"
+    is_delete = True
+
+    def __init__(self, table: Table):
+        self._table = table
+        self._whereclause = WhereClause()
+
+    @generative
+    def where(self, expr: ColumnElement) -> Self:
+        self._whereclause = self._whereclause.where(expr)
+        return self
+    
+    def _setup_execution(self, context: ExecutionContext) -> None:
+        pass
+
+def delete(table: Table) -> Delete:
+    return Delete(table)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,123 @@
+import pdb
+import uuid
+import pytest
+
+from normlite.sql.base import _CompileState, CompilerState
+from normlite.sql.compiler import NotionCompiler
+from normlite.sql.dml import Delete, delete 
+from normlite.sql.elements import BooleanClauseList
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import Boolean, Date, Integer, String
+
+"""TDD for all select() use scenarios.
+
+Here you also find the key tests for the big refactor triggered by th new Notion client API.
+- The NotionCompiler shall deliver bind parameters in the Compiled.params
+"""
+@pytest.fixture
+def metadata() -> MetaData:
+    return MetaData()
+
+@pytest.fixture
+def students(metadata: MetaData) -> Table:
+    return Table(
+        'students',
+        metadata,
+        Column('name', String(is_title=True)),
+        Column('id', Integer()),
+        Column('is_active', Boolean()),
+        Column('start_on', Date()),
+        Column('grade',  String())
+    )
+
+@pytest.fixture
+def delete_stmt(students: Table) -> Delete:
+    return delete(students)
+
+#---------------------------------------------
+# Operation generation tests
+#---------------------------------------------
+def test_delete_generate_operation_no_where_clause(students: Table, delete_stmt: Delete):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+
+    stmt = (
+        delete_stmt
+    )
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+
+    assert asdict['operation']['endpoint'] == 'databases'
+    assert asdict['operation']['request'] == 'query'
+    assert asdict['path_params']['database_id'] == ":database_id"
+    assert "in_trash" in asdict["payload"]
+    assert "page_size" in asdict["payload"]
+
+#---------------------------------------------
+# WHERE tests
+#---------------------------------------------
+def test_delete_generate_operation_with_where_clause(students: Table, delete_stmt: Delete):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+
+    stmt = (
+        delete_stmt
+        .where(students.c.name == 'Galileo Galilei')
+    )
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+
+    assert asdict['operation']['endpoint'] == 'databases'
+    assert asdict['operation']['request'] == 'query'
+    assert asdict['path_params']['database_id'] == ":database_id"
+    assert "in_trash" in asdict["payload"]
+    assert "page_size" in asdict["payload"]
+    assert "filter" in asdict["payload"]
+    assert asdict["payload"]["filter"]["property"] == "name"
+    assert "title" in asdict["payload"]["filter"]
+    assert asdict["payload"]["filter"]["title"] == {"equals": ":param_0"}
+    assert 'param_0' in compiled.params
+
+def test_where_generative_multi_clause(students: Table, delete_stmt: Delete):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+
+    stmt = (
+        delete_stmt
+        .where(students.c.name == 'Galileo Galilei')
+        .where(students.c.id <= 1000)
+    )
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+
+    assert isinstance(stmt._whereclause.expression, BooleanClauseList)
+    assert len(stmt._whereclause.expression.clauses) == 2
+    assert 'filter' in asdict['payload']
+    assert asdict['payload']['filter'] == {
+        'and': [
+            {
+                'property': 'name', 
+                'title': {
+                    'equals': ':param_0'
+                }
+            },
+            {
+                'property': 'id',
+                'number': {
+                    'less_than_or_equal_to': ':param_1'
+                }
+            }
+        ]        
+    }
+
+    assert 'param_0' in compiled.params
+    assert 'param_1' in compiled.params
+    assert len(compiled.params) == 2 + 1        # :database_id is also a bind parameter!
+
+


### PR DESCRIPTION
This version introduces the `Delete` class, and its constructor `delete()`, which model a SQL DELETE statement. The `SqlCompiler` and its concrete implementation `NotionCompiler` have been extended to support the visiting of the new `Delete` class.

Relates to #13.