### PR TITLE
fix(notiondbapi): `Cursor.rowcount` returns the size of the current r…

### DIFF
--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -250,9 +250,12 @@ class Cursor:
         .. versionchanged:: 0.9.0
             This version adds support for row counting in case of multiple result sets
         """
-        rs = self._current_result_set
-        return -1 if rs is None else len(rs)   
-    
+        if not self._result_sets:
+            return -1
+        
+        # sum of all result sets in the cursor
+        return sum(len(rs) for rs in self._result_sets)
+        
     @property
     def lastrowid(self) -> Optional[int]:
         """This read-only attribute provides the rowid of the last modified row.

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -660,3 +660,24 @@ def test_next_on_last_result_set_exhausts_results(
 
     # no more result sets
     assert cursor.fetchone() is None
+
+def test_rowcount_returns_sum_of_resultsets(
+    cursor: Cursor,
+    prefilled_client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+    database_id: str,
+):
+    pages = return_all_pages_in_database(prefilled_client, database_id)
+    params = [build_trash_operation(p["id"]) for p in pages]
+
+    cursor._inject_description(row_description)
+
+    cursor.executemany(
+        operation={
+            "endpoint": "pages",
+            "request": "update"
+        },
+        parameters=params
+    )
+
+    assert cursor.rowcount == len(pages)


### PR DESCRIPTION
…esult set only.

This version fixes the `Cursor.rowcount` attribute to return the sum of the size of all result sets. The `Cursor.executemany()` method produces multiple result sets.