### PR TITLE
feat(sql): Add DELETE SQL statement execution ([#13](https://github.c…

### DIFF
--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -230,16 +230,32 @@ class Connection:
 
         # 4. normalize params, options, payload
         ctx.pre_exec()
-        if ctx.execution_style == ExecutionStyle.SINGLE:
-            return self._execute_single(ctx)
+        elem = ctx.invoked_stmt
+
+        # 5. statement prepares execution
+        elem._setup_execution(ctx)      
+
+        if ctx.execution_style == ExecutionStyle.EXECUTE:
+            self._execute_single(ctx)
         
-        raise NotImplementedError('SINGLE execution style supported only.')
+        elif ctx.execution_style == ExecutionStyle.EXECUTEMANY:
+            self._execute_many(ctx)
+        
+        else:
+            raise NotImplementedError(f"'{ctx.execution_style}' execution style not supported.")
+        
+        # 7. the execution is mechanically complete before semantic interpretation begins
+        #    make lastrowid, rowcount, etc. available to the result
+        ctx.post_exec()
+
+        # 8. result interpretation
+        #    semantic reconstruction / reflection for DDL statements
+        elem._finalize_execution(ctx)   
+
+        return ctx.setup_cursor_result()
 
     def _execute_single(self, context: ExecutionContext) -> CursorResult:
         elem = context.invoked_stmt
-
-        # 5. statement prepares execution
-        elem._setup_execution(context)      
         
         # 6. side effects happen (HTTP)
         try:
@@ -251,15 +267,19 @@ class Connection:
         except Error as exc:
             elem._handle_dbapi_error(exc, context)
 
-        # 7. the execution is mechanically complete before semantic interpretation begins
-        #    make lastrowid, rowcount, etc. available to the result
-        context.post_exec()
+    
+    def _execute_many(self, context: ExecutionContext) -> CursorResult:
+        elem = context.invoked_stmt
 
-        # 8. result interpretation
-        #    semantic reconstruction / reflection for DDL statements
-        elem._finalize_execution(context)   
-
-        return context.setup_cursor_result()
+        # 6. side effects happen (HTTP)
+        try:
+            self._engine.do_executemany(
+                context.cursor, 
+                context.bulk_operation, 
+                context.bulk_parameters
+            )
+        except Error as exc:
+            elem._handle_dbapi_error(exc, context)
 
     def _resolve_execution_options(self, stmt_execution_options: ExecutionOptions) -> ExecutionOptions:
         """Resolve the connection's execution options with the statement's ones."""
@@ -865,7 +885,16 @@ class Engine:
     ) -> None:
         """Execute an operation on the supplied DBAPI cursor."""
         cursor.execute(operation, parameters)
-                        
+
+    def do_executemany(
+            self,
+            cursor: DBAPICursor,
+            operation: dict,
+            parameters: list[dict]
+    ) -> None:
+        """Execute the same operation over multiple parameters."""
+        cursor.executemany(operation, parameters)
+
 class Inspector:
     """Provide facilities for inspecting database objects.
 

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -49,7 +49,7 @@ import pdb
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 import copy
 
-from normlite.exceptions import ArgumentError
+from normlite.exceptions import ArgumentError, InvalidRequestError
 from normlite.engine.interfaces import _CoreMultiExecuteParams, ExecutionOptions
 from normlite.sql.resultschema import SchemaInfo
 from normlite.utils import frozendict
@@ -68,14 +68,22 @@ class ExecutionStyle(Enum):
     .. versionadded:: 0.8.0
     """
     
-    SINGLE = auto()
-    """A single operation is executed."""
-
-    RESULT_BULK = auto()
-    """Multiple operations are executed on a result.
+    EXECUTE = auto()
+    """A single operation is executed.
     
+    It indicates cursor.execute() will be used.
+
+    .. versionchanged:: 0.9.0
+    """
+
+    EXECUTEMANY = auto()
+    """Multiple operations are executed on a query result.
+
+    It indicates that cursor.execute() will be used.
     This execution style is used for DELETE/UPDATE statements where the execution loop is
     driven by the query results.
+
+    .. versionchanged:: 0.9.0
     """
 
     PARAMETER_BULK = auto()
@@ -250,6 +258,24 @@ class ExecutionContext:
     .. versionadded: 0.9.0
     """
 
+    bulk_operation: Optional[dict]
+    """The operation to be executed when :attr:`execution_style` is :attr:`ExecutionStyle.EXCUTEMANY`.
+    
+    .. versionadded:: 0.9.0
+    """
+
+    bulk_parameters: Optional[list[dict]]
+    """The parameters set for the bulk operation when :attr:`execution_style` is :attr:`ExecutionStyle.EXCUTEMANY`.
+
+    .. versionadded:: 0.9.0
+    """
+
+    internal_cursor: Optional[DBAPICursor]
+    """The cursor used internally for prefetching Notion pages in delete/update.
+    
+    .. versionadded:: 0.9.0
+    """
+
     def __init__(
             self,
             engine: Engine,
@@ -273,20 +299,18 @@ class ExecutionContext:
         self.payload = None
         self._result = None
         self._rowcount = None
+        self.bulk_operation = None
+        self.bulk_parameters = None
+        self.internal_cursor = None
 
     def _determine_execution_style(self) -> ExecutionStyle:
-        params = self.distilled_params
+        stmt = self.invoked_stmt
 
-        # Single execution: no parameters or exactly one parameter set
-        if len(params) == 1:
-            return ExecutionStyle.SINGLE
+        # delete
+        if stmt.is_delete:
+            return ExecutionStyle.EXECUTEMANY
 
-        # Bulk execution
-        if self.compiled._compiler_state.is_insert:
-            return ExecutionStyle.PARAMETER_BULK
-
-        # update/delete
-        return ExecutionStyle.RESULT_BULK
+        return ExecutionStyle.EXECUTE
 
     @property
     def operation(self) -> dict:
@@ -319,12 +343,7 @@ class ExecutionContext:
             dbapi_params['query_params'] = self.query_params
 
         if self.payload:
-            dbapi_params['payload'] = (
-                self.payload[0]
-                if self.execution_style in (ExecutionStyle.SINGLE, ExecutionStyle.RESULT_BULK)
-                else
-                self.payload
-            )
+            dbapi_params['payload'] = self.payload
 
         return dbapi_params
     
@@ -357,12 +376,11 @@ class ExecutionContext:
             )
 
         if 'payload' in self.compiled_dict:
-            self.payload = [
-                self._bind_params(
+            self.payload = self._bind_params(
                     copy.deepcopy(self.compiled_dict['payload']),
                     resolved_params
-                )
-            ]
+            )
+            
 
         if resolved_params:
             raise ArgumentError(

--- a/src/normlite/engine/cursor.py
+++ b/src/normlite/engine/cursor.py
@@ -143,6 +143,9 @@ class CursorResult:
     def __iter__(self) -> Iterator[Row]:
         """Provide an iterator for this cursor result.
 
+        .. versionchanged:: 0.9.0
+            This version adds support for multiple result sets returned by the underlying DBAPI cursor.
+
         .. versionchanged:: 0.7.0   
             Raise :exc:`ResourceClosedError` if it was previously closed.
         
@@ -155,13 +158,12 @@ class CursorResult:
             Iterator[Row]: The row iterator.
         """
         self._check_if_closed()
-        for raw_row in self._cursor:
+
+        for raw_row in self._cursor._iter_all():
             yield Row(self._metadata, raw_row)
 
-        # close the result set
-        self._metadata = _NO_CURSOR_RESULT_METADATA
-        self._cursor.close()        
-    
+        self.close()    
+
     def one(self) -> Row:
         """Return exactly one row or raise an exception.
 
@@ -180,18 +182,26 @@ class CursorResult:
         """
         self._check_if_closed()
 
-        if not self._metadata.returns_row:
-            raise NoResultFound('No row was found when one was required.')
-        
-        if self._cursor.rowcount > 1:
-            raise MultipleResultsFound('Multiple rows were found when exactly one was required.')
-        
-        return self.all()[0]
+        row = self.fetchone()
+        if row is None:
+            raise NoResultFound("No row was found when one was required.")
+
+        second = self.fetchone()
+        if second is not None:
+            raise MultipleResultsFound(
+                "Multiple rows were found when exactly one was required."
+            )
+
+        self.close()
+        return row
     
     def all(self) -> Sequence[Row]:
         """Return all rows in a sequence.
 
         This method closes the result set after invocation. Subsequent calls will return an empty sequence.
+
+        .. versionchanged:: 0.9.0
+            This version adds support for multiple result sets returned by the underlying DBAPI cursor.
 
         .. versionchanged:: 0.7.0   
             Raise :exc:`ResourceCloseError` if it was previously closed.
@@ -207,17 +217,12 @@ class CursorResult:
         self._check_if_closed()
 
         if not self._metadata.returns_row:
-            return list()
-        
-        raw_rows = self._cursor.fetchall()  # [(id_val, archived_val, in_trash_val, col1_val, ...), ...]
-        #row_sequence = [Row(self._metadata, row_data) for row_data in raw_rows]
-        row_sequence = list()
-        for row_data in raw_rows:
-            row = Row(self._metadata, row_data)
-            row_sequence.append(row)
+            return []
+
+        rows = [Row(self._metadata, raw) for raw in self._cursor._iter_all()]
 
         self.close()
-        return row_sequence
+        return rows    
     
     def first(self) -> Optional[Row]:
         """Return the first row or ``None`` if no row is present.
@@ -225,7 +230,9 @@ class CursorResult:
         Note:
             This method closes the result set and discards remaining rows.
 
-        .. versionchanged:: 0.7.0  Raise :exc:`ResourceClosedError` if it was previously closed.
+        .. versionchanged:: 0.7.0  
+            Raise :exc:`ResourceClosedError` if it was previously closed.
+
         .. versionadded:: 0.5.0
 
 
@@ -239,39 +246,38 @@ class CursorResult:
 
         if not self._metadata.returns_row:
             return None
-        
-        rows = list(self.all())
-        return rows[0]
+
+        row = self.fetchone()
+        self.close()
+        return row
     
     def fetchone(self) -> Optional[Row]:
         """Fetch the next row.
 
         When all rows are exhausted, returns ``None``.
 
+        .. versionchanged:: 0.9.0
+            This version adds support for multiple result sets returned by the underlying DBAPI cursor.
+
         .. versionadded:: 0.5.0
 
         Returns:
             Optional[Row]: The row object in the result.
         """
+        self._check_if_closed()
+
         if not self._metadata.returns_row:
-            # underlying DBAPI cursor is closed or no rows returned from a query
             return None
 
-        try:
-            next_row = self._cursor.fetchone()
-        except InterfaceError:
-            # Either call to cursor execute() did not produce results or execute() was not called yet
-            self._metadata = _NO_CURSOR_RESULT_METADATA
-            self._cursor.close()        
-            return None
-        
-        if next_row:
-            # the next row is not empty ()
-            return Row(self._metadata, next_row)
-        
-        # next_row is an empty tuple
-        return None
+        while True:
+            raw = self._cursor.fetchone()
+            if raw is not None:
+                return Row(self._metadata, raw)
 
+            # move to next result set
+            if not self._cursor.nextset():
+                return None
+            
     def fetchall(self) -> Sequence[Row]:
         """Synonim for :class:`CursorResult.all()` method.
 
@@ -284,10 +290,13 @@ class CursorResult:
         """
         return self.all()
     
-    def fetchmany(self) -> Sequence[Row]:
+    def fetchmany(self, size: Optional[int] = None) -> Sequence[Row]:
         """Fetch many rows.
 
         When all rows are exhausted, returns an empty sequence.
+
+        .. versionchanged:: 0.9.0
+            This version adds support for multiple result sets returned by the underlying DBAPI cursor.
 
         .. versionadded:: 0.5.0
 
@@ -297,8 +306,26 @@ class CursorResult:
         Returns:
             Sequence[Row]: All rows or an empty sequence when exhausted.
         """
-        raise NotImplementedError
-    
+        self._check_if_closed()
+
+        if not self._metadata.returns_row:
+            return []
+
+        n = self._cursor.arraysize if size is None else size
+        result = []
+
+        while len(result) < n:
+            chunk = self._cursor.fetchmany(n - len(result))
+            result.extend(Row(self._metadata, r) for r in chunk)
+
+            if len(result) >= n:
+                break
+
+            if not self._cursor.nextset():
+                break
+
+        return result    
+
     def close(self) -> None:
         """Close the cursor result.
         

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -702,6 +702,23 @@ class Cursor:
 
         self._result_index += 1
         return True
+
+    def _iter_all(self) -> Iterator[tuple]:
+        """Iterate over all rows across all result sets.
+        
+        This is a private API used by :class:`normlite.engine.cursor.CursorResult` to return all rows.
+
+        .. versionadded:: 0.9.0
+        """
+        self._check_closed()
+
+        if not self._result_sets:
+            raise ProgrammingError(
+                "Cursor result set is empty. No execute*() call was issued."
+            )
+
+        for rs in self._result_sets:
+            yield from rs
     
     def close(self) -> None:
         """Close the cursor now.

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+from copy import Error
+from operator import itemgetter
 import pdb
 from types import MappingProxyType
 from typing import Any, Optional, Protocol, Self, Sequence, Union, TYPE_CHECKING
@@ -24,6 +26,7 @@ from normlite._constants import SpecialColumns
 from normlite.exceptions import ArgumentError
 from normlite.sql.base import Executable, ClauseElement, generative
 from normlite.sql.elements import BindParameter, BooleanClauseList, ColumnElement
+from normlite.sql.resultschema import SchemaInfo
 
 if TYPE_CHECKING:
     from normlite.sql.schema import Column, Table, ReadOnlyColumnCollection
@@ -439,7 +442,53 @@ class Delete(ExecutableClauseElement, HasTable):
         return self
     
     def _setup_execution(self, context: ExecutionContext) -> None:
+        elem = context.invoked_stmt
+
+        # create a second cursor for the internal query
+        internal_cursor = context.connection._engine.raw_connection().cursor()
+        context.internal_cursor = internal_cursor
+
+        # IMPORTANT: inject the description in the cursor prior to use it
+        schema_info: SchemaInfo = SchemaInfo.from_table(
+            self._table,
+            [col.name for col in self._table.c]    
+        )
+        internal_cursor._inject_description(schema_info.as_sequence())
+
+        # execute the compiled query
+        try:
+            context.engine.do_execute(
+                internal_cursor,
+                context.operation,
+                context.parameters
+            )
+        except Error as exc:
+            elem._handle_dbapi_error(exc, context)
+
+        pages = internal_cursor.fetchall()
+
+        # build parameters for pages.update
+        bulk_params = []
+        get_object_id = itemgetter(0)
+
+        for page in pages:
+            bulk_params.append({
+                "path_params": {"page_id": get_object_id(page)},
+                "payload": {"in_trash": True}
+            })
+
+        context.bulk_operation = {
+            "endpoint": "pages",
+            "request": "update"
+        }
+
+        context.bulk_parameters = bulk_params
+    
+    def _finalize_execution(self, context: ExecutionContext) -> None:
+        # if preserve_rowcount then set the rowcount and consume the result
+        #result = context.setup_cursor_result()
         pass
+
 
 def delete(table: Table) -> Delete:
     return Delete(table)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -10,7 +10,7 @@ from normlite.sql.reflection import ReflectedTableInfo
 from normlite.notion_sdk.getters import get_object_id, rich_text_to_plain_text
 from normlite.sql.compiler import NotionCompiler
 from normlite.sql.ddl import CreateTable, DropTable
-from normlite.sql.dml import insert, select
+from normlite.sql.dml import insert, select, delete
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import Boolean, Date, Integer, Number, String
 
@@ -194,8 +194,8 @@ def test_resolve_params_for_insert(engine: Engine, students: Table, insert_value
     )
     ctx.pre_exec()
 
-    assert ctx.execution_style == ExecutionStyle.SINGLE
-    payload = ctx.payload[0]
+    assert ctx.execution_style == ExecutionStyle.EXECUTE
+    payload = ctx.payload
     assert payload['parent']['database_id'] == students.get_oid()
     assert payload['properties']['id']['number'] == 6789012
 
@@ -210,11 +210,11 @@ def test_resolve_params_for_select(engine: Engine, students: Table):
     )
     ctx.pre_exec()
 
-    assert ctx.execution_style == ExecutionStyle.SINGLE
+    assert ctx.execution_style == ExecutionStyle.EXECUTE
     assert ctx.path_params['database_id'] == students.get_oid()
     assert ctx.query_params.get('filter_properties') is not None
     assert 'id' in ctx.query_params['filter_properties']
-    name_col_val = ctx.payload[0]['filter']['title']['equals']
+    name_col_val = ctx.payload['filter']['title']['equals']
     assert name_col_val == 'Galileo Galilei'
 
 def test_resolve_params_for_create_table(students: Table, engine: Engine):
@@ -229,9 +229,9 @@ def test_resolve_params_for_create_table(students: Table, engine: Engine):
     )
     ctx.pre_exec()
 
-    assert ctx.execution_style == ExecutionStyle.SINGLE
+    assert ctx.execution_style == ExecutionStyle.EXECUTE
 
-    payload = ctx.payload[0]
+    payload = ctx.payload
     assert payload['parent']['page_id'] == engine._user_tables_page_id
     assert rich_text_to_plain_text(payload['title']) == 'students'
 
@@ -427,6 +427,40 @@ def is_valid_uuid4(uuid_string: str) -> bool:
         return False
     
     return True
+
+def test_execute_dml_context_delete_prefetch(
+    engine: Engine, 
+    students: Table
+):
+    # create database and mock reflection
+    database_id = create_students_db(engine)
+    students._sys_columns["object_id"]._value = database_id
+
+    # add rows
+    inserted_ids = add_students_rows(engine, students)
+
+    # construct select with projection
+    delete_stmt = (
+        delete(students)
+        .where(students.c.start_on.after(date(1580,1,1)))
+    )
+
+    # stmt._execute_on_connection(connection, distilled_params, execution_options)
+    compiled = delete_stmt.compile(engine._sql_compiler)
+    cursor = engine.raw_connection().cursor()
+    ctx = ExecutionContext(
+        engine,
+        engine.connect(),
+        cursor=cursor,
+        compiled=compiled,
+        execution_options={"preserve_rowcount": True}
+    )
+
+    # Connection._execute_result_bulk(context) -> CursorResult:
+    ctx.pre_exec()
+    elem = ctx.invoked_stmt
+    elem._setup_execution(ctx)
+    
 
 def test_execute_ddl_context_create_table_returning_id_and_title(engine: Engine, students: Table):
     students._db_parent_id = engine._user_tables_page_id

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -54,6 +54,7 @@ def test_delete_generate_operation_no_where_clause(students: Table, delete_stmt:
     assert asdict['path_params']['database_id'] == ":database_id"
     assert "in_trash" in asdict["payload"]
     assert "page_size" in asdict["payload"]
+    assert compiled._compiler_state.is_delete
 
 #---------------------------------------------
 # WHERE tests

--- a/tests/test_delete_exec_pipe.py
+++ b/tests/test_delete_exec_pipe.py
@@ -1,0 +1,236 @@
+from datetime import date
+import pdb
+import uuid
+from faker import Faker
+import pytest
+
+from normlite.engine.base import Engine, create_engine
+from normlite.engine.context import ExecutionContext, ExecutionStyle
+from normlite.engine.interfaces import _distill_params
+from normlite.sql.reflection import ReflectedTableInfo
+from normlite.notion_sdk.getters import get_object_id, rich_text_to_plain_text
+from normlite.sql.compiler import NotionCompiler
+from normlite.sql.ddl import CreateTable, DropTable
+from normlite.sql.dml import ExecutableClauseElement, insert, select, delete
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import Boolean, Date, Integer, Number, String
+
+@pytest.fixture
+def mocked_db_id() -> str:
+    return str(uuid.uuid4())
+
+@pytest.fixture
+def metadata() -> MetaData:
+    return MetaData()
+
+@pytest.fixture
+def students(metadata: MetaData, mocked_db_id: str) -> Table:
+    students = Table(
+        'students',
+        metadata,
+        Column('name', String(is_title=True)),
+        Column('id', Integer()),
+        Column('is_active', Boolean()),
+        Column('start_on', Date()),
+        Column('grade',  String())
+    )
+    students._sys_columns["object_id"]._value = mocked_db_id      # ensure table is in reflected state
+    return students
+
+@pytest.fixture
+def insert_values() -> dict:
+    return dict(
+        name = 'Galileo Galilei',
+        id=123456,
+        is_active=False,
+        start_on=date(1690,1,1),
+        grade='A'
+    )
+
+@pytest.fixture
+def engine() -> Engine:
+    return create_engine('normlite:///:memory:')
+
+fake = Faker()
+Faker.seed(42)
+
+def generate_rows(
+    engine: Engine, 
+    students: Table,
+    n: int,
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+
+    # generate the pages
+    with engine.connect() as connection:
+        for _ in range(n):
+            stmt = insert(students).values(
+                name = fake.name(),
+                id=fake.random_int(100000, 999999),
+                is_active=True,
+                # fake.date() causes a TypeError, see issue 220 (https://github.com/giant0791/normlite/issues/220)
+                start_on=fake.date_between(start_date='-10y', end_date='today'),
+                grade=fake.random_element(["A", "B", "C", "D"])
+            )
+
+            connection.execute(stmt)
+
+MAX_ROWS = 10
+
+def setup_context(
+    engine: Engine,
+    elem: ExecutableClauseElement,
+) -> ExecutionContext:
+
+    parameters = None
+
+    # 1. compile the statement
+    compiler = engine._sql_compiler
+    compiled = elem.compile(compiler)
+
+    # 2. distill parameters
+    distilled_params = _distill_params(parameters)  
+
+    # 3. create the execution context
+    ctx = ExecutionContext(
+        engine,
+        engine.connect(),
+        engine.raw_connection().cursor(),
+        compiled,
+        distilled_params,
+    )
+
+    return ctx
+
+#--------------------------------------------------
+# delete context tests
+#--------------------------------------------------
+def test_rows_generation_works(
+    engine: Engine,
+    students: Table,
+):
+    # prefill database
+    generate_rows(engine, students, n=MAX_ROWS)
+
+    # check all pages have been correctly created
+    stmt = select(students).where(students.c.is_active.is_(True))
+    with engine.connect() as connection:
+        result = connection.execute(stmt, execution_options={"preserve_rowcount": True})
+    
+    rows = result.all()
+    all_existing = [not row["is_deleted"] for row in rows]
+
+    assert result.rowcount == MAX_ROWS
+    assert len(rows) == MAX_ROWS
+    assert all(all_existing)
+
+def test_delete_exec_ctx_execstyle_is_executemany(
+    engine: Engine,
+    students: Table,
+):
+    # prefill database
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    # 4. normalize params, options, payload
+    ctx = setup_context(engine, elem)
+    ctx.pre_exec()
+
+    assert ctx.execution_style == ExecutionStyle.EXECUTEMANY
+
+def test_delete_exec_ctx_prefetches_pages_to_delete(
+    engine: Engine,
+    students: Table,
+):
+    # prefill database
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    # 4. normalize params, options, payload
+    ctx = setup_context(engine, elem)
+    ctx.pre_exec()
+    elem = ctx.invoked_stmt
+
+    # 5. statement prepares execution
+    elem._setup_execution(ctx)      
+    assert len(ctx.bulk_parameters) == MAX_ROWS
+
+def test_delete_ctx_bulk_params_contain_all_rows(
+    engine: Engine,
+    students: Table,
+):
+    # prefill database
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    # 4. normalize params, options, payload
+    ctx = setup_context(engine, elem)
+    ctx.pre_exec()
+    elem = ctx.invoked_stmt
+
+    # 5. statement prepares execution
+    elem._setup_execution(ctx)      
+
+    stmt = select(students).where(students.c.is_active.is_(True))
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+    
+    rows_to_delete = result.all()
+    page_ids = [r["object_id"] for r in rows_to_delete]
+    expected_bp = [
+        {"path_params": {"page_id": page_id}, "payload": {"in_trash": True}}
+        for page_id in page_ids
+    ]
+
+    assert expected_bp == ctx.bulk_parameters
+
+def test_delete_ctx_execmany_deletes_all_rows(    
+    engine: Engine,
+    students: Table,
+):
+    # prefill database
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    # 4. normalize params, options, payload
+    ctx = setup_context(engine, elem)
+    ctx.pre_exec()
+    elem = ctx.invoked_stmt
+
+    # 5. statement prepares execution
+    elem._setup_execution(ctx)      
+    # 6. side effects happen (HTTP)
+    engine.do_executemany(
+        ctx.cursor, 
+        ctx.bulk_operation, 
+        ctx.bulk_parameters
+    )
+
+    stmt = select(students).where(students.c.is_active.is_(True))
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+    
+    rows = result.all()
+
+    assert len(rows) == 0
+
+def test_delete_complete_exec_pipeline(
+    engine: Engine,
+    students: Table,
+):
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    with engine.connect() as connection:
+        del_result = connection.execute(elem, execution_options={"preserve_rowcount": True})
+        del_rows = del_result.all()
+        stmt = select(students).where(students.c.is_active.is_(True))
+        sel_result = connection.execute(stmt)
+
+    rows = sel_result.all()
+
+    assert len(rows) == 0
+    assert del_result.rowcount == MAX_ROWS
+
+    


### PR DESCRIPTION
…om/giant0791/normlite/issues/13)).

This version adds support for the DELETE statement. The class `Delete` implements a two-phase protocol with a pre-fetch of all rows meeting the where-clause criteria and then an executemany-style cursor exeuction. The `dbapi2.Cursor` hase been extended to provide a private API to iterate over all result sets, the `_iter_all()` method.
Finally, the `cursor.CursorResult` has been refactored to use the `_iter_all()` in all its fetch*-methods (including `first()`, `one()`, and `all()`).

Closes #13, closes #195, closes #145.