### PR TITLE
refactor(sql): use DateTimeRange in Date filter processor ([#232](htt…

### DIFF
--- a/src/normlite/sql/type_api.py
+++ b/src/normlite/sql/type_api.py
@@ -84,6 +84,8 @@ from normlite.notion_sdk.getters import rich_text_to_plain_text
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
 from normlite.sql.elements import Operator, BooleanComparator, Comparator, NumberComparator, DateComparator, ObjectIdComparator, StringComparator, TimeStampStringISO8601Comparator
 
+DEFAULT_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+DEFAULT_DATE_FORMAT = "%Y-%m-%d"
 
 class TypeEngine(Protocol):
     """Base class for all Notion/SQL datatypes.
@@ -705,21 +707,62 @@ class DateTimeRange:
         }
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, DateTimeRange):
-            return NotImplemented
+        # -----------------------------------------
+        # Case 1: DateTimeRange
+        # -----------------------------------------
+        if isinstance(other, DateTimeRange):
+            return (
+                self.start == other.start and
+                self.end == other.end and
+                self.timezone == other.timezone and
+                self._is_date_only == other._is_date_only
+            )
 
-        return (
-            self.start == other.start and
-            self.end == other.end and
-            self.timezone == other.timezone
-        )
+        # -----------------------------------------
+        # Case 2: date
+        # -----------------------------------------
+        if isinstance(other, date) and not isinstance(other, datetime):
+            try:
+                other_dtr = DateTimeRange(other)
+            except Exception:
+                return False
+            return self == other_dtr
+
+        # -----------------------------------------
+        # Case 3: datetime
+        # -----------------------------------------
+        if isinstance(other, datetime):
+            pdb.set_trace()
+            try:
+                other_dtr = DateTimeRange(other)
+            except Exception:
+                return False
+            return self == other_dtr
+
+        # -----------------------------------------
+        # Case 4: ISO string
+        # -----------------------------------------
+        if isinstance(other, str):
+            try:
+                other_dtr = DateTimeRange(other)
+            except Exception:
+                return False
+            return self == other_dtr
+
+        # -----------------------------------------
+        # Fallback
+        # -----------------------------------------
+        return NotImplemented
 
     def __repr__(self) -> str:
+        if self._is_date_only:
+            return self.start.strftime(DEFAULT_DATE_FORMAT)
+
         def fmt(dt: datetime) -> str:
             if dt is None:
                 return "None"
-            
-            return dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+                       
+            return dt.strftime(DEFAULT_DATETIME_FORMAT)
 
         if self.end:
             return f"{fmt(self.start)} - {fmt(self.end)}"
@@ -745,7 +788,7 @@ class Date(TypeEngine):
     })
 
     def bind_processor(self):
-        def process(value: Union[str, date, datetime, DateTimeRange,    None]):
+        def process(value: Union[str, date, datetime, DateTimeRange, None]):
             if value is None:
                 return None
 
@@ -793,16 +836,43 @@ class Date(TypeEngine):
                     f"Received: {value} ({type(value).__name__})"
                 ) from e
 
+            if dtr.end is not None:
+                raise ValueError(
+                    f"{self.get_col_spec()} filter does not accept date ranges; "
+                    "use a single value (start only)"
+                )            
+            
             # -----------------------------------------
             # Extract start date (Notion filter semantics)
             # -----------------------------------------
             start = dtr.start
 
-            # Notion expects date-only string for filters like on_or_after
-            return start.date().isoformat()
+            # -----------------------------------------
+            # Case 1: date-only
+            # -----------------------------------------
+            if dtr._is_date_only:
+                return start.date().isoformat()
+
+            # -----------------------------------------
+            # Case 2: timezone (IANA)
+            # -----------------------------------------
+            if dtr.timezone is not None:
+                dt = start.astimezone(dtr.timezone)
+                return dt.isoformat(timespec="seconds")
+
+            # -----------------------------------------
+            # Case 3: offset-aware datetime
+            # -----------------------------------------
+            if start.tzinfo is not None:
+                return start.isoformat(timespec="seconds")
+
+            # -----------------------------------------
+            # Case 4: naive datetime (allowed by Notion)
+            # -----------------------------------------
+            return start.isoformat(timespec="seconds")
 
         return process
-    
+
     def get_col_spec(self):
         return "date"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,15 @@ from normlite.notiondbapi.dbapi2 import Connection, Cursor
 from normlite.proxy.server import create_app
 from normlite.proxy.state import transaction_manager, notion
 
+# conftest.py
+
+def pytest_configure(config):
+    # The first argument is the section ('markers')
+    # The second argument is the marker name and its description
+    config.addinivalue_line(
+        "markers", "filter_proc: marks tests related to filter value processing"
+    )
+
 @pytest.fixture(scope="session")
 def api_key() -> str:
     # This is a fake key, read the real one from env variable

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 import pdb
 import uuid
+from zoneinfo import ZoneInfo
 import pytest
 
 from normlite.sql.base import _CompileState, CompilerState
@@ -8,7 +9,7 @@ from normlite.sql.compiler import NotionCompiler
 from normlite.sql.dml import Select, select
 from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList
 from normlite.sql.schema import Column, MetaData, Table
-from normlite.sql.type_api import Boolean, Date, Integer, String
+from normlite.sql.type_api import Boolean, Date, DateTimeRange, Integer, String
 
 """TDD for all select() use scenarios.
 
@@ -89,6 +90,24 @@ def test_date_col_expr(students: Table):
     assert compiled['property'] == 'start_on'
     assert compiled['date'] == {'after': ':param_0'}
 
+def test_datetimerange_col_expr(students: Table):
+    nc = NotionCompiler()
+    nc._compiler_state = CompilerState()
+    exp = students.c.start_on.after(DateTimeRange("1690-01-01"))
+    compiled: dict = None
+    with nc._compiling(new_state=_CompileState.COMPILING_WHERE):
+        compiled = exp._compiler_dispatch(nc)
+
+    assert exp.column is students.c.start_on
+    assert isinstance(exp, BinaryExpression)
+    assert isinstance(exp.value, BindParameter)
+    assert exp.value.key == 'param_0'
+    assert students.c.start_on.type_ is exp.value.type_
+    assert exp.value.effective_value == date(1690,1,1)
+    assert exp.value.effective_value == DateTimeRange(date(1690,1,1))
+    assert compiled['property'] == 'start_on'
+    assert compiled['date'] == {'after': ':param_0'}
+
 def test_bool_col_expr(students: Table):
     nc = NotionCompiler()
     nc._compiler_state = CompilerState()
@@ -151,6 +170,39 @@ def test_where_generative_one_clause(students: Table, select_stmt: Select):
     }
 
     assert 'param_0' in compiled.params
+
+def test_where_multi_date_clauses(students: Table, select_stmt: Select):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+
+    stmt = (
+        select_stmt
+        .where(students.c.start_on.after("2026-03-01"))
+        .where(students.c.start_on.before(datetime(2026, 3, 31)))
+        .where(students.c.start_on.after(datetime(2026, 3, 31, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))))
+        .where(students.c.start_on.after(DateTimeRange("2021-05-10T12:00:00", timezone="America/Los_Angeles")))
+    )
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    raw1 = compiled.params["param_0"].effective_value
+    proc1 = compiled.params["param_0"].type_.filter_value_processor()
+    raw2 = compiled.params["param_1"].effective_value
+    proc2 = compiled.params["param_1"].type_.filter_value_processor()
+    raw3 = compiled.params["param_2"].effective_value
+    proc3 = compiled.params["param_2"].type_.filter_value_processor()
+    raw4 = compiled.params["param_3"].effective_value
+    proc4 = compiled.params["param_3"].type_.filter_value_processor()
+    val1 = proc1(raw1)
+    val2 = proc2(raw2)
+    val3 = proc3(raw3)
+    val4 = proc4(raw4)
+
+    # Notion expects ISO 8601 dates only
+    assert val1 == "2026-03-01"
+    assert val2 == "2026-03-31T00:00:00"
+    assert val3 == "2026-03-31T12:00:00+02:00"
+    assert val4 == "2021-05-10T12:00:00-07:00"
 
 def test_where_generative_multi_clause(students: Table, select_stmt: Select):
     mocked_db_id = str(uuid.uuid4())

--- a/tests/test_type_api.py
+++ b/tests/test_type_api.py
@@ -1,5 +1,5 @@
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 import pdb
 from zoneinfo import ZoneInfo
@@ -18,6 +18,10 @@ from normlite import (
 
 from normlite.exceptions import ArgumentError, InvalidRequestError
 from normlite.sql.type_api import DateTimeRange, ObjectId, ArchivalFlag
+
+@pytest.fixture
+def filter_proc():
+    return Date().filter_value_processor()
 
 @pytest.mark.parametrize('type_obj, no_obj, py_obj, no_type', [
     (
@@ -168,7 +172,7 @@ def test_type_engine_datetimerange_dt_only_w_tz_raises():
     (
         Date(), 
         {"date": {"start": "2023-02-23", "end": "2023-04-23", "time_zone": None}}, 
-        DateTimeRange(datetime(2023,2,23), datetime(2023,4,23)), 
+        DateTimeRange(date(2023,2,23), "2023-04-23"), 
         "date"
     ),
     (
@@ -200,3 +204,113 @@ def test_archivalflag_raises_if_bind_is_attempted():
     with pytest.raises(InvalidRequestError):
         bind = type_obj.bind_processor()
 
+#----------------------------------------------------
+# filter value processing for Date objects
+#----------------------------------------------------
+
+@pytest.mark.filter_proc
+def test_filter_datetime_with_tzinfo_preserves_offset(filter_proc):
+    value = datetime(2026, 3, 31, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+
+    result = filter_proc(value)
+
+    assert result == "2026-03-31T12:00:00+02:00"
+
+@pytest.mark.filter_proc
+def test_filter_dtr_with_timezone_preserves_offset(filter_proc):
+    value = DateTimeRange(
+        "2021-05-10T12:00:00",
+        timezone="America/Los_Angeles"
+    )
+
+    result = filter_proc(value)
+
+    # May vary depending on DST, so compute expected dynamically
+    expected = (
+        value.start
+        .astimezone(value.timezone)
+        .isoformat(timespec="seconds")
+    )
+
+    assert result == expected
+    assert result.endswith("-07:00") or result.endswith("-08:00")
+
+@pytest.mark.filter_proc
+def test_filter_dtr_timezone_not_stripped(filter_proc):
+    value = DateTimeRange(
+        "2021-05-10T12:00:00",
+        timezone="America/Los_Angeles"
+    )
+
+    result = filter_proc(value)
+
+    # Previously buggy behavior returned no offset
+    assert "T" in result
+    assert "+" in result or "-" in result[-6:]  # crude but effective
+
+@pytest.mark.filter_proc
+def test_filter_date_only(filter_proc):
+    value = DateTimeRange("2021-05-10")
+
+    result = filter_proc(value)
+
+    assert result == "2021-05-10"
+
+@pytest.mark.filter_proc
+def test_filter_naive_datetime(filter_proc):
+    value = datetime(2021, 5, 10, 12, 0)
+
+    result = filter_proc(value)
+
+    assert result == "2021-05-10T12:00:00"
+
+@pytest.mark.filter_proc
+def test_filter_iso_string_with_offset(filter_proc):
+    value = "2021-10-15T12:00:00-07:00"
+
+    result = filter_proc(value)
+
+    assert result == "2021-10-15T12:00:00-07:00"
+
+@pytest.mark.filter_proc
+def test_filter_iso_date_string(filter_proc):
+    value = "2021-05-10"
+
+    result = filter_proc(value)
+
+    assert result == "2021-05-10"
+
+@pytest.mark.filter_proc
+def test_filter_rejects_date_ranges(filter_proc):
+    value = DateTimeRange("2021-01-01", "2021-12-31")
+
+    with pytest.raises(ValueError):
+        filter_proc(value)
+
+@pytest.mark.filter_proc
+def test_filter_vs_bind_timezone_asymmetry():
+    date_type = Date()
+
+    bind = date_type.bind_processor()
+    filter_proc = date_type.filter_value_processor()
+
+    value = DateTimeRange(
+        "2021-05-10T12:00:00",
+        timezone="America/Los_Angeles"
+    )
+
+    bound = bind(value)
+    filtered = filter_proc(value)
+
+    # -----------------------------------------
+    # Bind → structured timezone
+    # -----------------------------------------
+    assert bound["date"]["time_zone"] == "America/Los_Angeles"
+    assert "T12:00:00" in bound["date"]["start"]
+    assert "+" not in bound["date"]["start"]  # no offset
+
+    # -----------------------------------------
+    # Filter → offset encoding
+    # -----------------------------------------
+    assert "time_zone" not in filtered
+    assert "+" in filtered or "-" in filtered[-6:]


### PR DESCRIPTION
…ps://github.com/giant0791/normlite/issues/232))

This version supports proper filter value processing for:
- date string: "2026-03-01"
- datetime: datetime(2026, 3, 31)
- datetime with tz: datetime(2026, 3, 31, 12, 0, tzinfo=ZoneInfo(...))
- DateTimeRange with tz: DateTimeRange(..., timezone="...")

Filters must encode timezone via offset because the Notion API filter payloads do not support the "time_zone" field.

Tests in test_type_api.py now cover these cases. Run them via: $ uv run pytest -m filter_proc tests/test_type_api.py

Closes #232