### PR TITLE
fix(engine): Test `test_drop_table` fails with `TypeError` ([#236](ht…

### DIFF
--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -966,7 +966,7 @@ class Inspector:
             # access the Notion property identifier associate to a column
             print(
                 f'Property "{students.c.student_name.name}": '
-                f'"{inspector.get_oid(students)}"')                  # uuid string associated to the property
+                f'"{inspector.get_oid(students.c.student_name)}"')                  # uuid string associated to the property
 
         .. versionadded:: 0.7.0
             The current version supports both Notion object and property identifiers.
@@ -976,6 +976,22 @@ class Inspector:
         """
 
         return has_id.get_oid()
+
+    def is_dropped(self, table: Union[Table, str]) -> bool:
+        """``True`` if table state is :attr:`normlite.engine.systemcatalog.TableState.DROPPED`.
+        
+        .. versionadded:: 0.9.0
+        """
+        from normlite.sql.schema import Table
+
+        if isinstance(table, (Table, str,)):
+            name = table.name if isinstance(table, Table) else table
+            state = self._engine.get_table_state(name)
+            return state is TableState.DROPPED
+        
+        raise ArgumentError(
+            f"Table or str argument expected, got '{table.__class__.__name__}' instead."
+        )
 
     def _find_table_in_catalog(self, name: str, catalog: str) -> dict:
         return self._engine._client.databases_query({

--- a/tests/test_context_refactored.py
+++ b/tests/test_context_refactored.py
@@ -293,16 +293,18 @@ def test_create_table(engine, students):
     assert not result.returns_rows
     assert result.rowcount == -1
     assert is_valid_uuid4(students.get_oid())
-    assert all(c._id for c in students._usr_columns)
+    assert all(c._id for c in students.user_columns)
 
 
 def test_drop_table(engine, students, students_db):
+    inspector = engine.inspect()
     result, ctx = run_context(engine, DropTable(students))
 
     with pytest.raises(ResourceClosedError):
         rows = result.all()
 
-    assert students.c.is_deleted
+    assert inspector.is_dropped(students)
+    assert inspector.is_dropped(students.name)
     assert not result.returns_rows
 
 


### PR DESCRIPTION
…tps://github.com/giant0791/normlite/issues/236)).

The failure was causeb by a misuse of the table column to test for the "is_delete" condition. This version extends the `Inspector` class to provide a public API `is_dropped(Table | str)` which returns True if the table is dropped.
Test was updated. Now, all tests pass.

Closes #236.