### PR TITLE
fix(sql): Multiple tests fails with `AttributeError`((#234)[https://g…

### DIFF
--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -404,7 +404,8 @@ class ExecutionContext:
             return
         
         schema = SchemaInfo.from_table(
-            self.invoked_stmt.get_table(), 
+            self.invoked_stmt.get_table(),
+            projected_sys_names=self.compiled._fetch_columns, 
             projected_usr_names=self.compiled.result_columns()
         )
         self.cursor._inject_description(schema.as_sequence())

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -320,9 +320,11 @@ class Cursor:
         """
         return self._paramstyle
     
-    def _inject_description(self, schema_entries: tuple[tuple, ...]) -> None:
-        description = _Description(schema_entries)
-        self._description = description.as_sequence()
+    def _inject_description(
+        self, 
+        schema_entries: tuple[tuple, ...],
+    ) -> None:
+        self._description = schema_entries
 
     def _check_closed(self) -> NoReturn:
         if self._closed:
@@ -339,7 +341,10 @@ class Cursor:
             `_parse_result_set()`.
         """
         self._check_closed()
-        rs = ResultSet(returned_obj, self._description)
+        rs = ResultSet.from_json(
+            self._description,
+            returned_obj
+        )
         self._result_sets.append(rs)
 
     def _reset_results(self) -> None:

--- a/src/normlite/notiondbapi/resultset.py
+++ b/src/normlite/notiondbapi/resultset.py
@@ -1,22 +1,23 @@
+from __future__ import annotations
 from operator import itemgetter
 import pdb
-from typing import Optional
+from typing import Any, Callable, Optional, Sequence
 
 from normlite._constants import SpecialColumns
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
+
+_SYSTEM_COLUMNS_PAGE = {
+    SpecialColumns.NO_ID: "id",                       # TODO: rename in "object_id"
+    SpecialColumns.NO_ARCHIVED: "archived",           # TODO: rename in "is_archived"   
+    SpecialColumns.NO_IN_TRASH: "in_trash",           # TODO: rename in "is_deleted"
+    SpecialColumns.NO_CREATED_TIME: "created_time",   # TODO: rename in "created_at"
+    #("updated_at", DBAPITypeCode.TIMESTAMP, "last_edited_time"),
+}
 
 
 class ResultSet:
     """DBAPI-level representation of a Notion result set."""
 
-    _SYSTEM_COLUMNS_PAGE = (
-        (SpecialColumns.NO_ID, DBAPITypeCode.ID, "id"),                              # TODO: rename in "object_id"
-        (SpecialColumns.NO_ARCHIVED, DBAPITypeCode.ARCHIVAL_FLAG, "archived"),       # TODO: rename in "is_archived"   
-        (SpecialColumns.NO_IN_TRASH, DBAPITypeCode.ARCHIVAL_FLAG, "in_trash"),       # TODO: rename in "is_deleted"
-        (SpecialColumns.NO_CREATED_TIME, DBAPITypeCode.TIMESTAMP, "created_time"),   # TODO: rename in "created_at"
-
-        #("updated_at", DBAPITypeCode.TIMESTAMP, "last_edited_time"),
-    )    
 
     _SYSTEM_COLUMNS_DATABASE = (
         (SpecialColumns.NO_ID, DBAPITypeCode.ID, "id"),                              # TODO: rename in "object_id"
@@ -33,18 +34,30 @@ class ResultSet:
     _pg_oid_getter = itemgetter(0)
     _db_oid_getter = itemgetter(3) 
 
-    def __init__(self, notion_obj:dict, description: tuple[tuple, ...]):
+    def __init__(
+        self,
+        description: tuple[tuple, ...],
+        object_type: str,
+        rows: list[tuple],
+    ):
         self._index = 0
         self._description = description
-        self._object_type = None
-        self._rows = self._from_json(notion_obj)
+        self._object_type = object_type
+        self._rows = rows
 
-    def _from_json(self, notion_obj: dict) -> list[tuple]:
+    @classmethod
+    def from_json(
+        cls, 
+        description: tuple[tuple, ...],
+        notion_obj: dict
+    ) -> ResultSet:
         if notion_obj["object"] == "list":
             results = notion_obj.get("results")
+            object_type = notion_obj["type"]
 
         else:
             results = [notion_obj]
+            object_type = notion_obj["object"]
 
         rows = []
 
@@ -52,17 +65,17 @@ class ResultSet:
             obj_type = obj["object"]
 
             if obj_type == "page":
-                self._object_type = obj_type
-                rows.append(self._process_page(obj))
+                object_type = obj_type
+                rows.append(cls._process_page(description, obj))
 
             elif obj_type == "database":
-                self._object_type = obj_type
-                rows.extend(self._process_database(obj))
+                object_type = obj_type
+                rows.extend(cls._process_database(obj))
 
             else:
                 raise NotImplementedError(obj_type)
 
-        return rows
+        return cls(description, object_type, rows)
 
     def __iter__(self):
         return self
@@ -111,34 +124,37 @@ class ResultSet:
         # each entry in the result set provides ids
         return [self._pg_oid_getter(r) for r in self._rows]
             
-    def _process_page(self, page: dict) -> tuple:
+    @classmethod
+    def _process_page(
+        cls, 
+        description: tuple[tuple, ...],        
+        page: dict,
+    ) -> tuple:
         """Normalize a page object."""
 
-        get_col_name = itemgetter(0)
-        get_syscol_name = itemgetter(2)
-        columns = [
-            get_col_name(d) 
-            for d in self._description 
-            if get_col_name(d) not in SpecialColumns
-        ]
-        
-        sys_cols = [get_syscol_name(c) for c in self._SYSTEM_COLUMNS_PAGE]
-        row = [page[col] for col in sys_cols]
+        row = []
+        properties = page.get("properties", {})
 
-        for col in columns:           
-            prop = page["properties"][col]
-            typ = prop.get("type")
-            row.append(prop[typ] if typ else None)     # value is available only if the page is returned by databases.query or pages.retrieve
+        for desc_entry in description:
+            col = desc_entry[0]
 
-        return tuple(row)
+            if col in SpecialColumns:
+                row.append(page.get(_SYSTEM_COLUMNS_PAGE[col]))
+            else:
+                prop = properties.get(str(col))
+                typ = prop.get("type")
+                row.append(prop.get(typ) if typ else None)
+
+        return tuple(row)    
     
-    def _process_database(self, database: dict) -> list[tuple]:
+    @classmethod
+    def _process_database(cls, database: dict) -> list[tuple]:
         """Normalize a database object."""
 
         rows = []
 
         # system columns
-        for colname, coltype, field in self._SYSTEM_COLUMNS_DATABASE:
+        for colname, coltype, field in cls._SYSTEM_COLUMNS_DATABASE:
             rows.append(
                 (
                     colname,

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -473,12 +473,28 @@ class NotionCompiler(SQLCompiler):
         projection = self._compiler_state.stmt._projection
 
         if projection:
-            # use select projections for the result columns    
-            self._compiler_state.result_columns = projection
-            query_params['filter_properties'] = projection
-        
+            # use select projections for the result columns
+            for col in projection:
+                if col.is_system:
+                    if col.name != "object_id":
+                        # object_id is always in fetch_columns by default, don't add it twice
+                        self._compiler_state.fetch_columns.append(col.name)
+    
+                else:
+                    self._compiler_state.result_columns.append(col.name)
+
+                if self._compiler_state.result_columns:
+                    query_params['filter_properties'] = self._compiler_state.result_columns
+
         else:
-            self._compiler_state.result_columns = [col.name for col in table.columns]
+            self._compiler_state.fetch_columns.extend(
+                [
+                    col.name 
+                    for col in table._sys_columns 
+                    if col.name != "object_id" and col.name != "table_name"
+                ]
+            )
+            self._compiler_state.result_columns = [col.name for col in table._usr_columns]
         
         if select._order_by.has_expression():
             sorts_obj = select._order_by._compiler_dispatch(self)

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -436,7 +436,7 @@ class Select(HasTable, ExecutableClauseElement):
                 raise ArgumentError(
                     f'Column: {col.name} does not belong to table: {self._table.name}'
                 )
-        self._projection = [col.name for col in columns]
+        self._projection = columns
 
     @generative
     def where(self, expr: ColumnElement) -> Self:

--- a/src/normlite/sql/type_api.py
+++ b/src/normlite/sql/type_api.py
@@ -813,6 +813,9 @@ class Date(TypeEngine):
                 return None
 
             self._raise_if_val_not_dict(value)
+            if value.get("date") is None:
+                value = {self.get_col_spec(): value}
+                
             return DateTimeRange.from_json(value)
 
         return process

--- a/tests/test_delete_exec_pipe.py
+++ b/tests/test_delete_exec_pipe.py
@@ -232,6 +232,7 @@ def test_delete_complete_exec_pipeline(
     assert len(rows) == 0
     assert del_result.rowcount == MAX_ROWS
 
+
 def test_delete_exec_pipeline_returning_syscols_only(
     engine: Engine,
     students: Table,

--- a/tests/test_resultmetadata.py
+++ b/tests/test_resultmetadata.py
@@ -1,0 +1,171 @@
+import pytest
+import itertools
+
+from normlite._constants import SpecialColumns
+from normlite.engine.resultmetadata import CursorResultMetaData
+from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
+
+
+# -------------------------------------------------------------
+# Important Pytest Constraint: 
+# Fixtures like row_description cannot be used inside 
+# parametrize directly.
+# -------------------------------------------------------------
+ROW_DESCRIPTION = (
+    (SpecialColumns.NO_ID, DBAPITypeCode.ID, None, None, None, None, None,),
+    (SpecialColumns.NO_ARCHIVED, DBAPITypeCode.ARCHIVAL_FLAG, None, None, None, None, None,),
+    (SpecialColumns.NO_IN_TRASH, DBAPITypeCode.ARCHIVAL_FLAG, None, None, None, None, None,),
+    (SpecialColumns.NO_CREATED_TIME, DBAPITypeCode.TIMESTAMP, None, None, None, None, None,),
+    ("name", DBAPITypeCode.TITLE, None, None, None, None, None,),
+    ("id", DBAPITypeCode.NUMBER, None, None, None, None, None,),
+    ("is_active", DBAPITypeCode.CHECKBOX, None, None, None, None, None,),
+    ("start_on", DBAPITypeCode.DATE, None, None, None, None, None,),
+    ("grade", DBAPITypeCode.RICH_TEXT, None, None, None, None, None,),
+)
+
+SYSTEM_DESC = ROW_DESCRIPTION[:4]
+USER_DESC = ROW_DESCRIPTION[4:]
+
+# ------------------------------------------------------------
+# Helper
+# ------------------------------------------------------------
+
+def all_desc_subsets(desc):
+    return list(
+        itertools.chain.from_iterable(
+            itertools.combinations(desc, r)
+            for r in range(len(desc) + 1)
+        )
+    )
+
+# ------------------------------------------------------------
+# Baseline behavior
+# ------------------------------------------------------------
+
+def test_no_projection_returns_all_columns():
+    meta = CursorResultMetaData(ROW_DESCRIPTION, is_ddl=False)
+
+    expected_keys = [col[0] for col in ROW_DESCRIPTION]
+
+    assert meta.keys == expected_keys
+    assert set(meta.key_to_index.keys()) == set(expected_keys)
+    assert set(meta.index_for_key.values()) == set(expected_keys)
+
+# ------------------------------------------------------------
+# System Column Invariants
+# ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "subset",
+    list(
+        itertools.chain.from_iterable(
+            itertools.combinations(SYSTEM_DESC, r)
+            for r in range(len(SYSTEM_DESC) + 1)
+        )
+    ),
+)
+def test_system_columns_preserve_identity_and_index(subset):
+    meta = CursorResultMetaData(subset, is_ddl=False)
+
+    expected_keys = [col[0] for col in subset]
+
+    # Keys must match exactly (no transformation)
+    assert meta.keys == expected_keys
+
+    # Index must match tuple position
+    for idx, key in enumerate(expected_keys):
+        assert meta.key_to_index[key] == idx
+        assert meta.index_for_key[idx] == key
+
+# ------------------------------------------------------------
+# User Column Invariants
+# ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "subset",
+    list(
+        itertools.chain.from_iterable(
+            itertools.combinations(USER_DESC, r)
+            for r in range(len(USER_DESC) + 1)
+        )
+    ),
+)
+def test_user_columns_preserve_order_and_mapping(subset):
+    meta = CursorResultMetaData(subset, is_ddl=False)
+
+    expected_keys = [col[0] for col in subset]
+
+    assert meta.keys == expected_keys
+
+    for idx, key in enumerate(expected_keys):
+        assert meta.key_to_index[key] == idx
+        assert meta.index_for_key[idx] == key
+
+# ------------------------------------------------------------
+# Mixed Column Invariants
+# ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "sys_subset,user_subset",
+    [
+        (SYSTEM_DESC[:2], USER_DESC[:2]),
+        (SYSTEM_DESC[2:], USER_DESC[2:]),
+        (SYSTEM_DESC[::2], USER_DESC[::2]),
+        (SYSTEM_DESC, USER_DESC),
+        ((), USER_DESC),
+        (SYSTEM_DESC, ()),
+    ],
+)
+def test_mixed_columns_consistency(sys_subset, user_subset):
+    combined = tuple(sys_subset) + tuple(user_subset)
+
+    meta = CursorResultMetaData(combined, is_ddl=False)
+
+    expected_keys = [col[0] for col in combined]
+
+    # Order must be exactly preserved
+    assert meta.keys == expected_keys
+
+    # Bidirectional mapping must hold
+    for idx, key in enumerate(expected_keys):
+        assert meta.key_to_index[key] == idx
+        assert meta.index_for_key[idx] == key
+
+# ------------------------------------------------------------
+# Strong Invariant: Roundtrip Mapping
+# ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "subset",
+    [
+        ROW_DESCRIPTION,
+        ROW_DESCRIPTION[:3],
+        ROW_DESCRIPTION[3:],
+        ROW_DESCRIPTION[::2],
+    ],
+)
+def test_roundtrip_key_index_mapping(subset):
+    meta = CursorResultMetaData(subset, is_ddl=False)
+
+    for key, idx in meta.key_to_index.items():
+        assert meta.index_for_key[idx] == key
+
+# ------------------------------------------------------------
+# Empty Description Edge Case
+# ------------------------------------------------------------
+
+def test_empty_description():
+    meta = CursorResultMetaData((), is_ddl=False)
+
+    assert meta.keys == []
+    assert meta.key_to_index == {}
+    assert meta.index_for_key == {}
+
+# ------------------------------------------------------------
+# DDL flag passthrough
+# ------------------------------------------------------------
+
+def test_is_ddl_flag():
+    meta = CursorResultMetaData(ROW_DESCRIPTION, is_ddl=True)
+
+    assert meta.is_ddl is True

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -259,6 +259,34 @@ def test_columns_subset_projection(students: Table):
     assert compiled.result_columns() == expected
     assert compiled._fetch_columns == ["object_id"]
 
+def test_explicit_object_id_exists_once_in_fetch_columns(students: Table):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+    stmt: Select = select(students.c.object_id, students.c.name, students.c.id, students.c.is_active)
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+    expected = ['name', 'id', 'is_active']
+
+    assert asdict['query_params']['filter_properties'] == expected
+    assert compiled.result_columns() == expected
+    assert compiled._fetch_columns == ["object_id"]
+
+def test_syscol_subset_in_fetch_columns_no_result_columns(students: Table):
+    mocked_db_id = str(uuid.uuid4())
+    students._sys_columns["object_id"]._value = mocked_db_id
+    stmt: Select = select(students.c.is_archived, students.c.is_deleted, students.c.created_at)
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+    expected = []
+
+    assert not asdict.get('query_params')
+    assert compiled.result_columns() == expected
+    assert compiled._fetch_columns == ["object_id", "is_archived", "is_deleted", "created_at"]
+
 def test_columns_all_projection(students: Table):
     mocked_db_id = str(uuid.uuid4())
     students._sys_columns["object_id"]._value = mocked_db_id
@@ -267,11 +295,13 @@ def test_columns_all_projection(students: Table):
     nc = NotionCompiler()
     compiled = stmt.compile(nc)
     asdict = compiled.as_dict()
-    expected = [
+    sys_expected = [
         'object_id', 
         'is_archived', 
         'is_deleted', 
         'created_at', 
+    ]
+    usr_expected = [
         'name', 
         'id', 
         'is_active', 
@@ -287,7 +317,8 @@ def test_columns_all_projection(students: Table):
     assert 'page_size' in asdict['payload']
     assert asdict['payload']['page_size'] == 100
     assert asdict["payload"]["in_trash"] == False
-    assert expected == compiled.result_columns()
+    assert usr_expected == compiled.result_columns()
+    assert sys_expected == compiled._fetch_columns
 
 #---------------------------------------------
 # ORDER BY tests


### PR DESCRIPTION
…ithub.com/giant0791/normlite/issues/234]).

This version ties page processing in the `ResultSet` with the dynamically constructed cursor description. DML compilation and context pre-execution now construct the description sequence based on the columns the user declares as returning.

Closes #234.