### PR TITLE
feat(sql): Design INSERT ... RETURNING as a post fetch operation ([#2…

### DIFF
--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -274,7 +274,7 @@ class Connection:
         # 6. side effects happen (HTTP)
         try:
             self._engine.do_executemany(
-                context.cursor, 
+                context._staged_result_cursor, 
                 context.bulk_operation, 
                 context.bulk_parameters
             )

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -49,7 +49,7 @@ import pdb
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 import copy
 
-from normlite.exceptions import ArgumentError, InvalidRequestError
+from normlite.exceptions import ArgumentError
 from normlite.engine.interfaces import _CoreMultiExecuteParams, ExecutionOptions
 from normlite.sql._sentinels import VALUE_PLACEHOLDER
 from normlite.sql.resultschema import SchemaInfo
@@ -129,10 +129,16 @@ class ExecutionContext:
     .. versionadded::0.8.0
     """
 
-    cursor: DBAPICursor
-    """The DBAPI cursor holding the result set of the executed statement.
-    
-    .. versionchanged:: 0.8.0
+    _cursor: Optional[DBAPICursor]
+    """The DBAPI cursor holding the result set of the executed statement if no pre-fetch/post-fetch 
+    is required.
+
+    .. seealso::
+        :attr:`ExecutionContext._result_cursor`
+
+    .. versionchanged: 0.9.0
+
+    .. versionadded:: 0.8.0
     """
 
     compiled: Compiled
@@ -256,7 +262,13 @@ class ExecutionContext:
     _rowcount: Optional[int] 
     """The rowcount returned by an INSERT/UPDATE/DELETE/SELECT statement.
     
-    .. versionadded: 0.9.0
+    .. versionadded:: 0.9.0
+    """
+
+    _returned_primary_keys_rows: Optional[list[tuple]]
+    """The list of primary keys returned by the last executed DML statement as row.
+    
+    .. versionadded:: 0.9.0 
     """
 
     bulk_operation: Optional[dict]
@@ -271,13 +283,17 @@ class ExecutionContext:
     .. versionadded:: 0.9.0
     """
 
-    internal_cursor: Optional[DBAPICursor]
-    """The cursor used internally for prefetching Notion pages in delete/update.
+    _result_cursor: Optional[DBAPICursor]
+    """The cursor used internally for prefetching/postfetching Notion pages in delete/update/insert.
     
     .. versionadded:: 0.9.0
     """
 
-
+    _staged_result_cursor: Optional[DBAPICursor]
+    """The cursor used internally to route results after pre-fetch/post-fetching.
+    
+    .. versionadded:: 0.9.0
+    """
 
     def __init__(
             self,
@@ -291,7 +307,7 @@ class ExecutionContext:
     ) -> None:
         self.engine = engine
         self.connection = connection
-        self.cursor = cursor
+        self._cursor = cursor
         self.compiled = compiled
         self.compiled_dict = compiled.as_dict()
         self.invoked_stmt = compiled._element
@@ -302,9 +318,37 @@ class ExecutionContext:
         self.payload = None
         self._result = None
         self._rowcount = None
+        self._returned_primary_keys_rows = None
         self.bulk_operation = None
         self.bulk_parameters = None
-        self.internal_cursor = None
+        self._result_cursor = None
+        self._staged_result_cursor = None
+
+    @property
+    def cursor(self) -> Optional[DBAPICursor]:
+        """Return the effective DBAPI cursor for this execution.
+
+        This property implements **cursor routing**, selecting the cursor that
+        represents the *final, user-visible outcome* of the execution.
+        
+        Design principle
+        ----------------
+        The decision of *which cursor to expose* is made **entirely upstream**
+        during the execution pipeline, specifically in the statement’s
+        ``_finalize_execution()`` phase. This property does **not** contain any
+        conditional logic related to statement type (INSERT/UPDATE/DELETE),
+        execution options, or returning behavior.
+
+        Instead, it simply reflects the outcome of that decision:
+
+        - If a post-processing step (e.g. bulk update, post-fetch, RETURNING)
+        has produced a new cursor, it will have been assigned to
+        :attr:`_result_cursor` and is returned here.
+        - Otherwise, the original execution cursor (:attr:`_cursor`) is returned.
+
+        .. versionadded:: 0.9.0
+        """
+        return self._result_cursor or self._cursor
 
     def _determine_execution_style(self) -> ExecutionStyle:
         stmt = self.invoked_stmt
@@ -405,10 +449,11 @@ class ExecutionContext:
         
         schema = SchemaInfo.from_table(
             self.invoked_stmt.get_table(),
-            projected_sys_names=self.compiled._fetch_columns, 
-            projected_usr_names=self.compiled.result_columns()
+            execution_names=self.compiled.fetch_columns(), 
+            projected_names=self.compiled.result_columns()
         )
-        self.cursor._inject_description(schema.as_sequence())
+    
+        self._cursor._inject_description(schema.as_sequence())
 
     def post_exec(self) -> None:
         """Perform row counting preservation after execution.
@@ -422,7 +467,7 @@ class ExecutionContext:
 
         exec_opts = self.execution_options
         if exec_opts.get('preserve_rowcount', False):
-            self._rowcount =  self.cursor.rowcount
+            self._rowcount =  self._cursor.rowcount
             return
         
         self._rowcount = -1

--- a/src/normlite/engine/cursor.py
+++ b/src/normlite/engine/cursor.py
@@ -140,6 +140,16 @@ class CursorResult:
         rowcount = self.context.get_rowcount()
         return -1 if rowcount is None else rowcount
     
+    @property
+    def returned_primary_keys_rows(self) -> Optional[list[tuple]]:
+        """Return the value of :attr:`normlite.engine.context.ExecutionContext._returned_primary_keys_rows
+        as a list of tuples representing rows.
+        
+        .. versionadded:: 0.9.0
+        """
+        return self.context._returned_primary_keys_rows
+    
+    
     def __iter__(self) -> Iterator[Row]:
         """Provide an iterator for this cursor result.
 
@@ -164,11 +174,29 @@ class CursorResult:
 
         self.close()    
 
+    def _soft_close(self) -> None:
+        """Soft close the cursor result.
+        
+        Soft closing means the underlying result set is closed (:attr:`returns_row` is `` False``), 
+        but the cursor result itself it is not, that is no :exc:`normlite.exceptions.ResourceCloseError` 
+        is raised.
+        This method is private and it is used by user classes that are perform result interpretation.
+
+        .. versionadded:: 0.9.0
+        """
+        self._metadata = _NO_CURSOR_RESULT_METADATA
+
     def one(self) -> Row:
         """Return exactly one row or raise an exception.
 
+        Note:
+            This method soft-closes the result set.
+
+        .. versionchanged:: 0.9.0
+            Soft-closing logic added.
+            
         .. versionchanged:: 0.7.0   
-            Raise :exc:`ResourceCloseError` if it was previously closed.
+            Raise :exc:`normlite.exceptions.ResourceCloseError` if it was previously closed.
         
         .. versionadded:: 0.5.0
 
@@ -192,7 +220,7 @@ class CursorResult:
                 "Multiple rows were found when exactly one was required."
             )
 
-        self.close()
+        self._soft_close()
         return row
     
     def all(self) -> Sequence[Row]:
@@ -200,9 +228,13 @@ class CursorResult:
 
         This method closes the result set after invocation. Subsequent calls will return an empty sequence.
 
+        Note:
+            This method soft-closes the result set.
+        
         .. versionchanged:: 0.9.0
-            This version adds support for multiple result sets returned by the underlying DBAPI cursor.
-
+            This version adds support for multiple result sets returned by the underlying DBAPI cursor,
+            and soft-closing logic.
+            
         .. versionchanged:: 0.7.0   
             Raise :exc:`ResourceCloseError` if it was previously closed.
 
@@ -221,17 +253,20 @@ class CursorResult:
 
         rows = [Row(self._metadata, raw) for raw in self._cursor._iter_all()]
 
-        self.close()
+        self._soft_close()
         return rows    
     
     def first(self) -> Optional[Row]:
         """Return the first row or ``None`` if no row is present.
 
         Note:
-            This method closes the result set and discards remaining rows.
+            This method soft-closes the result set and discards remaining rows.
+
+        .. versionchanged:: 0.9.0
+            After this method is 
 
         .. versionchanged:: 0.7.0  
-            Raise :exc:`ResourceClosedError` if it was previously closed.
+            Raise :exc:`normlite.exceptions.ResourceClosedError` if it was previously closed.
 
         .. versionadded:: 0.5.0
 
@@ -248,7 +283,7 @@ class CursorResult:
             return None
 
         row = self.fetchone()
-        self.close()
+        self._soft_close()
         return row
     
     def fetchone(self) -> Optional[Row]:
@@ -300,9 +335,6 @@ class CursorResult:
 
         .. versionadded:: 0.5.0
 
-        Raises:
-            NotImplementedError: Method not implemented yet.
-
         Returns:
             Sequence[Row]: All rows or an empty sequence when exhausted.
         """
@@ -329,13 +361,17 @@ class CursorResult:
     def close(self) -> None:
         """Close the cursor result.
         
-        After a cursor result is closed, the :attr:`returns_row` returns ``False``.
+        After a cursor result is closed, the :attr:`returns_row` returns ``False``, and
+        all public API methods raise :exc:`normlite.exceptions.ResourceClosedError`.
+
+        .. versionchanged:: 0.9.0
+            This version uses :meth:`_soft_close` to soft-close the underlying DBAPI cursor.
 
         .. versionadded:: 0.7.0
             This method closes the underlying DBAPI cursor and manages the internal state.
     
         """
-        self._metadata = _NO_CURSOR_RESULT_METADATA
+        self._soft_close()
         self._cursor.close()
         self._closed = self._cursor._closed
 

--- a/src/normlite/engine/interfaces.py
+++ b/src/normlite/engine/interfaces.py
@@ -74,7 +74,22 @@ class ExecutionOptions(TypedDict, total=False):
 
     .. seealso::
         
-        See :attr:`normlite.engine.cursor.CursorResult.rowcount` for notes regarding the behavior of this attribute.
+        See :attr:`normlite.engine.cursor.CursorResult.rowcount` for notes regarding the behavior of 
+        this attribute.
+
+    .. versionadded:: 0.9.0
+    """
+
+    implicit_returning: Optional[bool]
+    """When True, the ``cursor.returned_primary_keys`` attribute will be unconditionally memoized within 
+    the result and made available via the :attr:`normlite.engine.cursor.CursorResult.returned_primary_keys` attribute.
+
+    .. seealso::
+
+        See :attr:`normlite.engine.cursor.CursorResult.returned_primary_keys` for notes regarding 
+        the behavior of this attribute.
+
+    .. versionadded:: 0.9.0
     """
 
 _CoreSingleExecuteParams = Mapping[str, Any]

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -302,8 +302,35 @@ class Cursor:
             # no rows modified
             return None
         
-        return uuid.UUID(last_inserted_rowids[-1]).int
-
+        return uuid.UUID(last_inserted_rowids[-1][0]).int
+    
+    @property
+    def lastrowid_as_string(self) -> Optional[str]:
+        rs = self._current_result_set
+        if rs is None:
+            return None       
+        
+        # extract the object UUID of the last row as 128-bit integer
+        last_inserted_rowids = rs.last_inserted_rowids
+        if last_inserted_rowids is None:
+            # no rows modified
+            return None
+        
+        return last_inserted_rowids[-1][0]
+    
+    @property
+    def _last_inserted_row_ids(self) -> Optional[list[tuple]]:
+        """Return all row ids of the last inserted rows as flattened out list.
+        
+        .. versionadded:: 0.9.0
+        """
+        all_ids = []
+        for rs in self._result_sets:
+            if rs.last_inserted_rowids is not None:
+                all_ids.extend(rs.last_inserted_rowids)
+        
+        return all_ids
+        
     @property
     def paramstyle(self) -> DBAPIParamStyle:
         """String constant stating the type of parameter marker formatting expected by the interface. 

--- a/src/normlite/notiondbapi/resultset.py
+++ b/src/normlite/notiondbapi/resultset.py
@@ -110,7 +110,7 @@ class ResultSet:
         return desc
     
     @property
-    def last_inserted_rowids(self) -> Optional[list[str]]:
+    def last_inserted_rowids(self) -> Optional[list[tuple]]:
         if self._object_type == "database":
             # the result set contains columns metadata from a database:
             # the first row only provides the database id
@@ -122,7 +122,7 @@ class ResultSet:
 
         # the result set contains pages
         # each entry in the result set provides ids
-        return [self._pg_oid_getter(r) for r in self._rows]
+        return [(self._pg_oid_getter(r),) for r in self._rows]
             
     @classmethod
     def _process_page(

--- a/src/normlite/sql/base.py
+++ b/src/normlite/sql/base.py
@@ -383,9 +383,13 @@ class Compiled:
         return self._compiled
     
     def result_columns(self) -> Optional[Sequence[str]]:
-        """Optionally return the column names for the cursor result."""
+        """Optionally return the user column names for the cursor result."""
         return self._result_columns
     
+    def fetch_columns(self) -> Sequence[str]:
+        """Return the system column names to be included in the cursor result"""
+        return self._fetch_columns
+
     def __str__(self) -> str:
         return self.string
     

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -29,7 +29,7 @@ from normlite.sql.base import _CompileState, SQLCompiler
 from normlite.sql.dml import Delete, OrderByClause
 from normlite.sql.elements import _BindRole, BooleanClauseList, Operator, OrderByExpression, ColumnElement
 from normlite.sql.elements import BindParameter
-from normlite.sql.schema import ReadOnlyColumnCollection
+from normlite.sql.schema import Column, ReadOnlyColumnCollection
 
 if TYPE_CHECKING:
     from normlite.sql.ddl import CreateTable, DropTable, ReflectTable
@@ -354,10 +354,20 @@ class NotionCompiler(SQLCompiler):
     def visit_insert(self, insert: Insert) -> dict:
         """Compile the ``INSERT`` DML statement.
 
-        This visit method compiles the DML :class:`normlite.sql.dml.Insert` construct into a Notion payload for the pages.create request.
+        This visit method compiles the DML :class:`normlite.sql.dml.Insert` construct into a Notion payload 
+        for the pages.create request.
+
+        Raises:
+            CompileError: If the RETURNING clause does not include the system column "object_id"
 
         Args:
             insert (Insert): The DML statement to be compiled.
+
+        .. versionchanged:: 0.9.0
+            This version adds full support for INSERT ... RETURNING.
+            It initializes the :attr:`normlite.sql.base.CompilerState.result_columns
+
+
 
         .. versionchanged:: 0.8.0
             This method extends parameterization via named argument also to the "database_id" key. Thus, the "parameters" dictionary 
@@ -372,6 +382,12 @@ class NotionCompiler(SQLCompiler):
         self._compiler_state.is_insert = True
         payload = {}
         db_id_key = None
+
+        # select the user columns to be included in the returned rows
+        self._compiler_state.result_columns = [
+            col.name 
+            for col in insert._returning
+        ]
 
         if insert._values is None:
             # create a mapping for all user columns with dummy values
@@ -403,10 +419,6 @@ class NotionCompiler(SQLCompiler):
             payload['properties'] = self._compile_insert_update_values(insert._values)
 
         operation = dict(endpoint='pages', request='create')
-
-        # IMPORTANT: concatenate the values tuple containing the special columns WITH the returning tuple.
-        # This ensures that the values for the special columns are always available even if the returning tuple is ().
-        self._compiler_state.result_columns = [col.name for col in insert._returning]
         return {'operation': operation, 'payload': payload}  
 
     def visit_order_by_clause(self, clause: OrderByClause) -> dict:
@@ -474,27 +486,19 @@ class NotionCompiler(SQLCompiler):
 
         if projection:
             # use select projections for the result columns
-            for col in projection:
-                if col.is_system:
-                    if col.name != "object_id":
-                        # object_id is always in fetch_columns by default, don't add it twice
-                        self._compiler_state.fetch_columns.append(col.name)
-    
-                else:
-                    self._compiler_state.result_columns.append(col.name)
+            self._compiler_state.fetch_columns = [
+                col.name
+                for col in projection
+            ]
 
-                if self._compiler_state.result_columns:
-                    query_params['filter_properties'] = self._compiler_state.result_columns
-
-        else:
-            self._compiler_state.fetch_columns.extend(
-                [
-                    col.name 
-                    for col in table._sys_columns 
-                    if col.name != "object_id" and col.name != "table_name"
+            if self._compiler_state.result_columns:
+                # add the filter_properties query parameters
+                # use user columns only
+                query_params['filter_properties'] = [
+                    col
+                    for col in self._compiler_state.result_columns
+                    if col not in SpecialColumns
                 ]
-            )
-            self._compiler_state.result_columns = [col.name for col in table._usr_columns]
         
         if select._order_by.has_expression():
             sorts_obj = select._order_by._compiler_dispatch(self)
@@ -522,6 +526,12 @@ class NotionCompiler(SQLCompiler):
             'in_trash': False,       # Always return non deleted pages only
         }
  
+        # select the user columns to be included in the returned rows
+        self._compiler_state.result_columns = [
+            col.name 
+            for col in delete._returning
+        ]
+
         table = delete.get_table()
         database_id = table.get_oid()
         if database_id is None:
@@ -548,7 +558,6 @@ class NotionCompiler(SQLCompiler):
             'path_params': path_params, 
             'payload': payload
         }
-        self._compiler_state.result_columns = [col.name for col in delete._returning]
         return compiled_dict
 
     def visit_binary_expression(self, expression: BinaryExpression) -> dict:

--- a/src/normlite/sql/ddl.py
+++ b/src/normlite/sql/ddl.py
@@ -131,6 +131,7 @@ class CreateTable(ExecutableDDLStatement):
         # result empty in the context.
         result = context.setup_cursor_result()
         rows = result.all()
+        result.close()
         data_as_tuples = [r.as_tuple() for r in rows]        
         reflected_table_info = ReflectedTableInfo.from_tuples(data_as_tuples)
         table = self._table
@@ -183,7 +184,7 @@ class DropTable(ExecutableDDLStatement):
     def _finalize_execution(self, context: ExecutionContext) -> None:
         # IMPORTANT: This consumes the result
         result = context.setup_cursor_result()
-        _ = result.all()
+        result.close()
         engine = context.engine
 
         # Ensure we have a valid sys_tables_page_id
@@ -239,7 +240,8 @@ class ReflectTable(ExecutableDDLStatement):
         # So reflection consumes the results by interpreting and leaves the
         # result empty in the context.
         result = context.setup_cursor_result()
-        rows = result.all()        
+        rows = result.all()
+        result.close()        
         data_as_tuples = [r.as_tuple() for r in rows]        
         self._reflected_table_info = ReflectedTableInfo.from_tuples(data_as_tuples)
         self._reflected_table._db_parent_id = context.engine._user_tables_page_id

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -21,7 +21,8 @@ from copy import Error
 from operator import itemgetter
 import pdb
 from types import MappingProxyType
-from typing import Any, Optional, Protocol, Self, Sequence, Union, TYPE_CHECKING
+from typing import Any, Callable, NoReturn, Optional, Protocol, Self, Sequence, Union, TYPE_CHECKING
+import uuid
 import warnings
 from normlite._constants import SpecialColumns
 from normlite.exceptions import ArgumentError
@@ -90,7 +91,6 @@ class UpdateBase(HasTable, ExecutableClauseElement):
     _table: Table = None
     """The table this executable is referred to."""
 
-
     def __init__(self, table: Table):
         self._table = table
 
@@ -118,12 +118,6 @@ class UpdateBase(HasTable, ExecutableClauseElement):
             if key in seen:
                 warnings.warn(
                     f"Column '{col.name}' already declared as returning, skipping."
-                )
-                continue
-
-            if col.is_system:
-                warnings.warn(
-                    f"System columns are always added to the RETURNING clause by default ('{col.name}')"
                 )
                 continue
 
@@ -290,12 +284,87 @@ class Insert(ValuesBase):
         return MappingProxyType(kv_pairs)
 
     def _setup_execution(self, context: ExecutionContext) -> None:
-        # nothing to be setup
-        pass
+        # setup only if returning is declared
+        if not self._returning:
+            return
+        
+        # 1. prepare result cursor (but don’t assign yet)
+        result_cursor = context.connection._engine.raw_connection().cursor()
+
+        fetch_schema = SchemaInfo.from_table(
+            self._table,
+            execution_names=None,
+            projected_names=context.compiled.result_columns()
+        )
+        
+        result_cursor._inject_description(fetch_schema.as_sequence())
+
+        # 2. stage it
+        context._staged_result_cursor = result_cursor
+
+        # 3. stage operation
+        context.bulk_operation = {
+            "endpoint": "pages",
+            "request": "retrieve"
+        }
+
+        # parameters will be filled in _finalize_execution()    
+
+    def _handle_dbapi_error(
+        self, 
+        exc: Error, 
+        context: ExecutionContext
+    ) -> Optional[NoReturn]:
+        
+        # all DBAPI errors propagate
+        raise
 
     def _finalize_execution(self, context: ExecutionContext) -> None:
-        # nothing to be finalized
-        pass
+        if self._returning:
+            at_leat_one_usr_column = any([
+                not col.is_system
+                for col in self._returning
+            ])
+
+            if at_leat_one_usr_column:
+                self._post_fetch_inserted_row(context)    
+
+            context._returned_primary_keys_rows = None
+            return
+        
+        implicit_returning = context.execution_options.get("implicit_returning", False)
+        if not implicit_returning:
+            result = context.setup_cursor_result()
+            result._soft_close()
+            context._returned_primary_keys_rows = None
+            return
+        
+        if implicit_returning:
+            result = context.setup_cursor_result()
+            result._soft_close()
+            context._returned_primary_keys_rows = context.cursor._last_inserted_row_ids
+
+    def _post_fetch_inserted_row(self, context: ExecutionContext) -> None:
+        elem = context.invoked_stmt
+
+        # build parameters for pages.retrieve
+        for row in context._cursor.fetchall():
+            context.bulk_parameters = [{
+                "path_params": {"page_id": row[0]}
+            }]
+
+        # execute post-fetch
+        try:
+            context.engine.do_executemany(
+                context._staged_result_cursor,
+                context.bulk_operation,
+                context.bulk_parameters
+            )
+        except Error as exc:
+            elem._handle_dbapi_error(exc, context)
+
+        # finalize cursor routing
+        context._result_cursor = context._staged_result_cursor
 
     def __repr__(self):
         kwarg = []
@@ -407,7 +476,13 @@ class Select(HasTable, ExecutableClauseElement):
             # a Table object has been provided
             table = entities[0]
             self._table = table
-            self._projection = []  # project all columns
+
+            # project all columns
+            self._projection = [
+                col
+                for col in self._table.c
+                if col.name != "table_name"
+            ]  
             return
 
         # A list of columns has been provided
@@ -486,33 +561,38 @@ class Delete(UpdateBase):
     def _setup_execution(self, context: ExecutionContext) -> None:
         elem = context.invoked_stmt
 
-        # create a second cursor for the internal query
-        internal_cursor = context.connection._engine.raw_connection().cursor()
-        context.internal_cursor = internal_cursor
-
-        # IMPORTANT: inject the description in the cursor prior to use it
-        fetch_schema: SchemaInfo = SchemaInfo.from_table(
+        # 1. prepare schema for compiled query
+        schema_for_query: SchemaInfo = SchemaInfo.from_table(
             self._table,
-            projected_sys_names=context.compiled._fetch_columns,
-            projected_usr_names=context.compiled.result_columns()    
+            execution_names=context.compiled.fetch_columns(),
+            projected_names=context.compiled.result_columns()    
         )
-        internal_cursor._inject_description(fetch_schema.as_sequence())
+        context._cursor._inject_description(
+            schema_for_query.as_sequence()
+        )
 
         # execute the compiled query
         try:
             context.engine.do_execute(
-                internal_cursor,
+                context._cursor,
                 context.operation,
                 context.parameters
             )
         except Error as exc:
             elem._handle_dbapi_error(exc, context)
 
-        pages = internal_cursor.fetchall()
+        pages = context._cursor.fetchall()
 
         # build parameters for pages.update
+        result_cursor = context.connection._engine.raw_connection().cursor()
+        schema_for_returning: SchemaInfo = SchemaInfo.from_table(
+            self._table,
+            execution_names=context.compiled.fetch_columns(),
+            projected_names=context.compiled.result_columns()    
+        )
+        result_cursor._inject_description(schema_for_returning.as_sequence())
         bulk_params = []
-        get_object_id = fetch_schema.column_getter("object_id")
+        get_object_id = schema_for_returning.column_getter("object_id")
 
         for page in pages:
             bulk_params.append({
@@ -520,6 +600,7 @@ class Delete(UpdateBase):
                 "payload": {"in_trash": True}
             })
 
+        context._staged_result_cursor = result_cursor
         context.bulk_operation = {
             "endpoint": "pages",
             "request": "update"
@@ -528,7 +609,22 @@ class Delete(UpdateBase):
         context.bulk_parameters = bulk_params
     
     def _finalize_execution(self, context: ExecutionContext) -> None:
-        pass
+        if self._returning:
+            # finalize cursor routing
+            context._result_cursor = context._staged_result_cursor
+            return
+
+        implicit_returning = context.execution_options.get("implicit_returning", False)
+        if not implicit_returning:
+            result = context.setup_cursor_result()
+            result._soft_close()
+            context._returned_primary_keys_rows = None
+            return
+        
+        if implicit_returning:
+            result = context.setup_cursor_result()
+            result._soft_close()
+            context._returned_primary_keys_rows = context.cursor._last_inserted_row_ids
 
 def delete(table: Table) -> Delete:
     return Delete(table)

--- a/src/normlite/sql/resultschema.py
+++ b/src/normlite/sql/resultschema.py
@@ -35,12 +35,42 @@
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from normlite._constants import SpecialColumns
-from normlite.exceptions import ArgumentError, InvalidRequestError, NoSuchColumnError
+from normlite.exceptions import InvalidRequestError, NoSuchColumnError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
 from normlite.sql.schema import Table
+
+def _merge_names(
+    execution_names: Optional[Sequence[str]],
+    projected_names: Optional[Sequence[str]],
+) -> List[str]:
+    """Merge execution and projected column names into a single ordered list.
+
+    Rules:
+    - execution_names are included first (internal requirements)
+    - projected_names follow (user projection)
+    - duplicates are removed while preserving order
+    - None is treated as an empty sequence
+
+    Args:
+        execution_names: Internal names required for execution.
+        projected_names: User-requested names.
+
+    Returns:
+        List[str]: Ordered, de-duplicated sequence of names.
+    """
+    seen = set()
+    result: List[str] = []
+
+    for source in (execution_names or [], projected_names or []):
+        for name in source:
+            if name not in seen:
+                seen.add(name)
+                result.append(name)
+
+    return result
 
 @dataclass(frozen=True)
 class ResultColumn:
@@ -49,28 +79,6 @@ class ResultColumn:
     type_code: DBAPITypeCode
     nullable: bool
 
-_SYSCOL_SCHEMA = {
-    SpecialColumns.NO_ID.value: ResultColumn(
-        name=SpecialColumns.NO_ID, 
-        type_code=DBAPITypeCode.ID, 
-        nullable=None
-    ),
-    SpecialColumns.NO_ARCHIVED.value: ResultColumn(
-        name=SpecialColumns.NO_ARCHIVED, 
-        type_code=DBAPITypeCode.ARCHIVAL_FLAG, 
-        nullable=None
-    ),
-    SpecialColumns.NO_IN_TRASH.value: ResultColumn(
-        name=SpecialColumns.NO_IN_TRASH, 
-        type_code=DBAPITypeCode.ARCHIVAL_FLAG, 
-        nullable=None
-    ),
-    SpecialColumns.NO_CREATED_TIME.value: ResultColumn(
-        name=SpecialColumns.NO_CREATED_TIME, 
-        type_code=DBAPITypeCode.TIMESTAMP, 
-        nullable=None
-    ),
-}
 
 @dataclass(frozen=True)
 class SchemaInfo:
@@ -89,8 +97,8 @@ class SchemaInfo:
         cls,
         table: Table,
         *,
-        projected_sys_names: Optional[Sequence[str]] = None,
-        projected_usr_names: Optional[Sequence[str]] = None,
+        execution_names: Optional[Sequence[str]] = None,
+        projected_names: Optional[Sequence[str]] = None,
     ) -> SchemaInfo:
         """Build schema information from a :class:`normlite.sql.schema.Table`.
 
@@ -98,9 +106,8 @@ class SchemaInfo:
 
         Args:
             table (Table): The table representive the authoritative source of the schema.
-            projected_sys_names (Optional[Sequence[str]]): The ordered projection list of system columns (Notion key values).
-            projected_usr_names (Optional[Sequence[str]]): The ordered projection list of user columns (Notion properties)
-                coming from :attr:`normlite.engine.context.ExecutionContext.compiled._result_columns`.
+            execution_names (Optional[Sequence[str]]): The ordered projection list of system columns (Notion key values) required for statement execution.
+            projected_names (Optional[Sequence[str]]): The ordered projection list of columns (Notion key valuses **and** properties) the user wants to have in the returned rows.
 
         Raises:
             NoSuchColumnError: If any of the column names in ``projection_names`` could not be found in the table.
@@ -111,49 +118,28 @@ class SchemaInfo:
         .. versionadded:: 0.9.0
         """
 
-        # always initialize the result_columns with sys cols
-        result_columns = []
-        if projected_sys_names is not None:
-            result_columns = [
-                _SYSCOL_SCHEMA[sysc.name] 
-                for sysc in table._sys_columns
-                if sysc.name in projected_sys_names
-            ]
+        result_columns: List[ResultColumn] = []
+        merged_columns = _merge_names(
+            execution_names=execution_names,
+            projected_names=projected_names,
+        )
 
-        else:
-            # always return all columns if projection is empty
-            result_columns = [
-                col
-                for col in _SYSCOL_SCHEMA.values()
-            ]
-
-        if projected_usr_names is not None:
-            for name in projected_usr_names:
-
-                # Table-declared columns
-                try:
-                    column = table.c[name]
-                except KeyError:
-                    raise NoSuchColumnError(
-                        f"Column '{name}' not found in table '{table.name}'."
-                    )
-
-                result_columns.append(
-                    ResultColumn(
-                        name=name,
-                        type_code=column.type_.get_dbapi_type(),
-                        nullable=None,
-                    )
+        for name in merged_columns:
+            # Table-declared columns
+            try:
+                column = table.c[name]
+            except KeyError:
+                raise NoSuchColumnError(
+                    f"Column '{name}' not found in table '{table.name}'."
                 )
-        else:
-            for column in table.c:
-                result_columns.append(
-                    ResultColumn(
-                        name=column.name,
-                        type_code=column.type_.get_dbapi_type(),
-                        nullable=None,
-                    )
+
+            result_columns.append(
+                ResultColumn(
+                    name=name,
+                    type_code=column.type_.get_dbapi_type(),
+                    nullable=None,
                 )
+            )
 
         return cls(tuple(result_columns))
     

--- a/tests/test_context_refactored.py
+++ b/tests/test_context_refactored.py
@@ -253,6 +253,17 @@ def test_insert_rowcount(engine, students, students_db, insert_values, preserve_
 
     assert result.rowcount == expected
 
+def test_insert_implicit_returning(engine, students, students_db, insert_values):
+    result = run_execute(
+        engine,
+        insert(students),
+        insert_values,
+        execution_options={"implicit_returning": True},
+    )
+
+    assert not result.returns_rows
+    assert len(result.returned_primary_keys_rows) == 1
+
 
 def test_select_projection(engine, populated_students, students):
     stmt = select(students.c.is_active)

--- a/tests/test_delete_exec_pipe.py
+++ b/tests/test_delete_exec_pipe.py
@@ -68,7 +68,6 @@ def generate_rows(
                 name = fake.name(),
                 id=fake.random_int(100000, 999999),
                 is_active=True,
-                # fake.date() causes a TypeError, see issue 220 (https://github.com/giant0791/normlite/issues/220)
                 start_on=fake.date_between(start_date='-10y', end_date='today'),
                 grade=fake.random_element(["A", "B", "C", "D"])
             )
@@ -238,7 +237,7 @@ def test_delete_exec_pipeline_returning_syscols_only(
     students: Table,
 ):
     generate_rows(engine, students, n=MAX_ROWS)
-    elem = delete(students).where(students.c.is_active.is_(True))
+    elem = delete(students).where(students.c.is_active.is_(True)).returning(students.c.object_id)
 
     with engine.connect() as connection:
         # query the database before deleting all rows
@@ -275,14 +274,13 @@ def test_delete_exec_pipeline_returning_usrcols(
     elem = (
         delete(students)
         .where(students.c.is_active.is_(True))
-        .returning(students.c.name, students.c.id)
+        .returning(students.c.object_id, students.c.name, students.c.id)
     )
-    #pdb.set_trace()
 
     with engine.connect() as connection:
         # query the database before deleting all rows
         stmt = (
-            select(students.c.name, students.c.id)
+            select(students.c.object_id, students.c.name, students.c.id)
             .where(students.c.is_active.is_(True))
         )
         result = connection.execute(stmt)
@@ -305,4 +303,60 @@ def test_delete_exec_pipeline_returning_usrcols(
         assert orig_row.object_id == del_rows[idx].object_id
         assert orig_row.name == del_rows[idx].name
         assert orig_row.id == del_rows[idx].id
+
+def test_delete_exec_pipeline_implicit_returning_true(
+    engine: Engine,
+    students: Table,
+):
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    with engine.connect() as connection:
+        # query the database before deleting all rows
+        stmt = select(students).where(students.c.is_active.is_(True))
+        result = connection.execute(stmt)
+        orig_rows = result.all()
+
+        # delete all rows
+        del_result = connection.execute(elem, execution_options={"implicit_returning": True})
+
+        # this query shall return no rows
+        stmt = select(students).where(students.c.is_active.is_(True))
+        sel_result = connection.execute(stmt)
+        rows = sel_result.all()
+
+    deleted_ids = [(r["object_id"],) for r in orig_rows]
+
+    assert len(rows) == 0
+    assert result.rowcount == MAX_ROWS
+    assert del_result.rowcount == MAX_ROWS
+    assert del_result.returned_primary_keys_rows == deleted_ids
+    assert not del_result.returns_rows
+
+def test_delete_exec_pipeline_implicit_returning_false(
+    engine: Engine,
+    students: Table,
+):
+    generate_rows(engine, students, n=MAX_ROWS)
+    elem = delete(students).where(students.c.is_active.is_(True))
+
+    with engine.connect() as connection:
+        # query the database before deleting all rows
+        stmt = select(students).where(students.c.is_active.is_(True))
+        result = connection.execute(stmt)
+        orig_rows = result.all()
+
+        # delete all rows
+        del_result = connection.execute(elem)
+
+        # this query shall return no rows
+        stmt = select(students).where(students.c.is_active.is_(True))
+        sel_result = connection.execute(stmt)
+        rows = sel_result.all()
+
+    assert len(rows) == 0
+    assert result.rowcount == MAX_ROWS
+    assert del_result.rowcount == MAX_ROWS
+    assert del_result.returned_primary_keys_rows is None
+    assert not del_result.returns_rows
 

--- a/tests/test_insert_exec_pipe.py
+++ b/tests/test_insert_exec_pipe.py
@@ -1,0 +1,192 @@
+from datetime import date
+import pdb
+from typing import Any, Mapping, Optional
+import uuid
+from faker import Faker
+import pytest
+
+from normlite.engine.base import Engine, create_engine
+from normlite.engine.context import ExecutionContext, ExecutionStyle
+from normlite.engine.interfaces import _distill_params
+from normlite.exceptions import CompileError
+from normlite.sql.dml import ExecutableClauseElement, insert, select, delete
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import Boolean, Date, Integer, String
+
+@pytest.fixture
+def mocked_db_id() -> str:
+    return str(uuid.uuid4())
+
+@pytest.fixture
+def metadata() -> MetaData:
+    return MetaData()
+
+@pytest.fixture
+def students(metadata: MetaData, mocked_db_id: str) -> Table:
+    students = Table(
+        'students',
+        metadata,
+        Column('name', String(is_title=True)),
+        Column('id', Integer()),
+        Column('is_active', Boolean()),
+        Column('start_on', Date()),
+        Column('grade',  String())
+    )
+    students._sys_columns["object_id"]._value = mocked_db_id      # ensure table is in reflected state
+    return students
+
+@pytest.fixture
+def engine() -> Engine:
+    engine = create_engine('normlite:///:memory:')
+    engine.execution_options(preserve_rowcount=True)
+    return engine
+
+
+fake = Faker()
+Faker.seed(42)
+
+def generate_values() -> dict:
+    return dict(
+        name = fake.name(),
+        id=fake.random_int(100000, 999999),
+        is_active=True,
+        start_on=fake.date_between(start_date='-10y', end_date='today'),
+        grade=fake.random_element(["A", "B", "C", "D"])
+    )
+
+def setup_context(
+    engine: Engine,
+    elem: ExecutableClauseElement,
+    *,
+    execution_options: Optional[Mapping[str, Any]] = None
+) -> ExecutionContext:
+
+    parameters = None
+
+    # 1. compile the statement
+    compiler = engine._sql_compiler
+    compiled = elem.compile(compiler)
+
+    # 2. distill parameters
+    distilled_params = _distill_params(parameters)  
+
+    # 3. create the execution context
+    ctx = ExecutionContext(
+        engine,
+        engine.connect(),
+        engine.raw_connection().cursor(),
+        compiled,
+        distilled_params,
+        execution_options=execution_options
+    )
+
+    return ctx
+
+def test_no_returning_no_returning_implicit_returns_none_pk(
+    engine: Engine,
+    students: Table
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+    values = generate_values()
+    stmt = insert(students).values(**values)
+
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+
+    assert not result.returns_rows
+    assert result.all() == []
+    assert result.returned_primary_keys_rows is None
+
+def test_no_returning_true_returning_implicit_returns_pks_only(
+    engine: Engine,
+    students: Table        
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+    values = generate_values()
+    stmt = insert(students).values(**values)
+
+    with engine.connect() as connection:
+        result = connection.execute(
+            stmt,
+            execution_options={"implicit_returning": True}
+        )
+
+    # metadata only since returning() is missing and returning_implicit is True
+    assert not result.returns_rows
+    assert result.all() == []
+    assert len(result.returned_primary_keys_rows) == 1
+
+
+def test_returning_false_returning_implicit_returns_all_cols_specified(
+    engine: Engine,
+    students: Table        
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+    values = generate_values()
+    stmt = (
+        insert(students)
+        .values(**values)
+        .returning(students.c.object_id, students.c.name)
+    )
+
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+
+    assert result.returns_rows
+    rows = result.all()
+    assert len(rows) == 1
+    assert rows[0].name == values["name"]
+    assert result.returned_primary_keys_rows is None
+
+def test_returning_includes_object_id_explicitly_only(
+    engine: Engine,
+    students: Table        
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+    values = generate_values()
+    stmt = (
+        insert(students)
+        .values(**values)
+        .returning(students.c.object_id, students.c.name)
+    )
+
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+
+    rows = result.all()
+    col_names = rows[0].keys()
+
+    assert len(rows) == 1
+    assert "object_id" in col_names
+    assert "name" in col_names
+    assert "is_deleted" not in col_names
+    assert len(col_names) == 2
+
+def test_returning_does_not_include_object_id_by_default(
+    engine: Engine,
+    students: Table        
+):
+    # create the table
+    students.create(bind=engine, checkfirst=True)
+    values = generate_values()
+    stmt = (
+        insert(students)
+        .values(**values)
+        .returning(students.c.name)
+    )
+
+    with engine.connect() as connection:
+        result = connection.execute(stmt)
+
+    rows = result.all()
+    col_names = rows[0].keys()
+
+    assert len(rows) == 1
+    assert "object_id" not in col_names
+    assert "name" in col_names
+    assert "is_deleted" not in col_names
+    assert len(col_names) == 1


### PR DESCRIPTION
…00](https://github.com/giant0791/normlite/issues/200)).

This version introduces support for RETURNING clause in INSERT and DELETE. A new execution option "implicit_returning" can be used instead to return the page ids of the modified pages as list of 1-value tuples (example: [(id1,), (id2,), ...]. New tests added, existing updated and extended.
All tests pass.

Closes #200, closes #223.