### PR TITLE
refactor(sql): Remove system column storing table name from `Table` (…

### DIFF
--- a/src/normlite/sql/ddl.py
+++ b/src/normlite/sql/ddl.py
@@ -247,12 +247,11 @@ class ReflectTable(ExecutableDDLStatement):
         self._reflected_table._db_parent_id = context.engine._user_tables_page_id
 
         # reflect columns
-        for colmeta in self._reflected_table_info.get_columns():
-            if colmeta.is_system and colmeta.name != "table_name":
+        for colmeta in self._reflected_table_info.get_reflectable_cols():
+            if colmeta.is_system:
                 self._reflected_table._sys_columns[colmeta.name]._value = colmeta.value
-                continue
            
-            if not colmeta.is_system:
+            else:
                 # assign user column ids
                 new_col = Column(
                     name=colmeta.name,
@@ -261,6 +260,7 @@ class ReflectTable(ExecutableDDLStatement):
                 )
                 new_col._set_parent(self._reflected_table)
                 self._reflected_table.append_column(new_col)
+        
 
     def _as_info(self) -> ReflectedTableInfo:
         return self._reflected_table_info

--- a/src/normlite/sql/reflection.py
+++ b/src/normlite/sql/reflection.py
@@ -74,6 +74,13 @@ class ReflectedTableInfo:
     def get_columns(self) -> Sequence[ReflectedColumnInfo]:
         return self._columns
     
+    def get_reflectable_cols(self) -> Sequence[ReflectedColumnInfo]:
+        return [
+            col 
+            for col in self._columns
+            if col.name != SpecialColumns.NO_TITLE
+        ]
+
     @normlite_deprecated("This method is deprecated and will be removed in a future version.")
     def get_column_names(self, include_all: Optional[bool] = True) -> Sequence[str]:
         if include_all:

--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -428,7 +428,6 @@ class Table(HasIdentifier):
         # initialize internal structures
         self._usr_columns = ColumnCollection()
         self._sys_columns = ColumnCollection()
-        self._constraints = set()
 
         # Always add system columns
         self._ensure_system_columns()
@@ -613,16 +612,10 @@ class Table(HasIdentifier):
             type_ = TimeStampStringISO8601(),
         )
 
-        table_name = SystemColumn(
-            name="table_name",
-            type_= String(is_title=True)
-        )
-
         self._add_system_column(object_id)
         self._add_system_column(is_archived)
         self._add_system_column(is_deleted)
         self._add_system_column(created_at)
-        self._add_system_column(table_name)
 
     def _create_pk_constraint(self) -> None:
         table_pks = [c for c in self._sys_columns if c.primary_key]

--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -183,14 +183,14 @@ def test_is_table_dropped_wrong_type_raises(engine: Engine, inspector: Inspector
     with pytest.raises(ArgumentError):
         _ = inspector.is_dropped({"wrong": "type"})
 
-@pytest.mark.skip("Requires table_name refactoring")
+#@pytest.mark.skip("Requires table_name refactoring")
 def test_engine_inspector_reflect_sys_table(engine: Engine, inspector: Inspector):
     metadata = MetaData()
     tables: Table = Table('tables', metadata)
     inspector.reflect_table(tables)
 
     assert tables._sys_columns["object_id"]._value == engine._tables_id
-    assert 'table_name' in tables.c
+    assert 'table_name' not in tables.c
     assert 'table_schema' in tables.c
     assert 'table_catalog' in tables.c
     assert 'table_id' in tables.c

--- a/tests/unit/sql/test_ddl_compilation.py
+++ b/tests/unit/sql/test_ddl_compilation.py
@@ -1,14 +1,12 @@
-import uuid
 import pytest
 
-from normlite.engine.base import Engine, create_engine
+from normlite.engine.base import Engine
 from normlite.exceptions import CompileError
 from normlite.notion_sdk.getters import get_property
 from normlite.sql.base import DDLCompiled
 from normlite.sql.ddl import CreateTable, DropTable, ReflectTable
 from normlite.sql.elements import _BindRole, BindParameter
-from normlite.sql.schema import Column, MetaData, Table
-from normlite.sql.type_api import Boolean, Date, Integer, String
+from normlite.sql.schema import Table
 
 
 #---------------------------------------------

--- a/tests/unit/sql/test_schema.py
+++ b/tests/unit/sql/test_schema.py
@@ -193,7 +193,7 @@ def test_table_contains_sys_columns_if_no_usr_cols_defined(metadata: MetaData):
     assert "is_deleted" in no_usr_col_table._sys_columns
     assert "is_archived" in no_usr_col_table._sys_columns
     assert "created_at" in no_usr_col_table._sys_columns
-    assert "table_name" in no_usr_col_table._sys_columns
+    assert "table_name" not in no_usr_col_table._sys_columns
 
 def test_sys_columns_api_names_correctly_mapped(metadata: MetaData):
     table = Table("no_usr_cols", metadata)
@@ -202,7 +202,6 @@ def test_sys_columns_api_names_correctly_mapped(metadata: MetaData):
     assert table._sys_columns.is_deleted.api_key() == "in_trash"
     assert table._sys_columns.is_archived.api_key() == "archived"
     assert table._sys_columns.created_at.api_key() == "created_time"
-    assert table._sys_columns.table_name.api_key() == "title"
 
 def test_sys_columns_cannot_be_redefined(metadata: MetaData):
     with pytest.raises(ArgumentError) as exc:
@@ -262,7 +261,7 @@ def test_table_repr_contains_sys_columns(students: Table):
     assert "is_deleted" in table_repr
     assert "is_archived" in table_repr
     assert "created_at" in table_repr
-    assert "table_name" in table_repr
+    assert "table_name" not in table_repr
 
 def test_table_valid_minimal():
     metadata = MetaData()


### PR DESCRIPTION
…[#247](https://github.com/giant0791/normlite/issues/247)).

This version removes the table name from the system columns. The class `ReflectedTableInfo` now provides a new method `.get_reflectable_cols()` which filters out the table name property from the Notion database object.

Closes #247.