### PR TITLE
ci: redesign CI/CD pipeline and add close() to AbstractNotionClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install deps
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=xml --cov-report=term-missing | tee pytest-coverage.txt
+
+      - name: Post coverage comment
+        if: github.event_name == 'pull_request'
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: pytest-coverage.txt
+
+      # ── Future: Codecov upload + README badge (milestone v1.0.0) ──────────────
+      # Requires: CODECOV_TOKEN secret configured in repository settings.
+      # Add badge to README.md once token is set up:
+      #   [![codecov](https://codecov.io/gh/giant0791/normlite/graph/badge.svg)](https://codecov.io/gh/giant0791/normlite)
+      #
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v4
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.xml
+      #     fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,3 @@
-#----------------------------------------------------
-# Release pipeline test version
-# ---------------------------------------------------
-
 name: Release
 
 on:
@@ -12,12 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write  # For PyPI trusted publishing
+      pull-requests: write
 
     steps:
+      - name: Ensure workflow runs from main
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "Error: release workflow must be triggered from main, got ${{ github.ref }}"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # important for commitizen
+          fetch-depth: 0
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -25,49 +28,37 @@ jobs:
       - name: Install deps
         run: uv sync --all-extras
 
-      - name: Configure Git user
+      - name: Configure Git
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
+      - name: Determine next version (dry run)
+        id: next
+        run: |
+          DRY=$(uv run cz bump --dry-run --yes 2>&1)
+          echo "$DRY"
+          VERSION=$(echo "$DRY" | grep -oP '\d+\.\d+\.\d+' | tail -1)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "branch=release/v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create release branch
+        run: git checkout -b ${{ steps.next.outputs.branch }}
+
       - name: Run commitizen bump
         run: uv run cz bump --yes
+
+      - name: Push release branch with tag
+        run: git push --follow-tags origin ${{ steps.next.outputs.branch }}
+
+      - name: Open pull request
         env:
-          CZ_USE_COMMITIZEN: "true"
-
-      - name: Push changes back to source branch
-        env:
-          REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.next.outputs.version }}
+          BRANCH: ${{ steps.next.outputs.branch }}
         run: |
-          git push --follow-tags origin HEAD:${REF_NAME}
-
-      - name: Build documentation
-        run: |
-          uv run sphinx-build -b html docs/ docs/_build/html --color
-
-      - name: Upload documentation
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/_build/html
-
-  deploy:
-    needs: release
-    runs-on: ubuntu-latest
-
-    # FIX: explicitly set permissions here too
-    permissions:
-      pages: write
-      id-token: write
-
-    # Deployment step *must* use this environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
-    # Optional: publish to PyPI using trusted publisher
-    # extention point not implemented yet
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "release: v${VERSION}" \
+            --body "Automated release PR for v${VERSION}. Merging will re-point the tag to the merge commit and deploy the documentation."

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -1,0 +1,67 @@
+name: Tag and Deploy
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag-and-deploy:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Re-point tag to merge commit
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          TAG=$(echo "$BRANCH" | sed 's|release/v||')
+          echo "Re-pointing tag ${TAG} to merge commit ${MERGE_SHA}"
+          git fetch --tags
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+          git tag "$TAG" "$MERGE_SHA"
+          git push origin "$TAG"
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install deps
+        run: uv sync --all-extras
+
+      - name: Build documentation
+        run: uv run sphinx-build -b html docs/ docs/_build/html --color
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy-docs:
+    needs: tag-and-deploy
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ addopts = [
     "-v",  
     "-s",  
 ] 
-testpaths = ["normlite/tests/unit"]
+testpaths = ["tests/unit"]
 
 [tool.coverage.run]
 branch = true

--- a/src/normlite/notion_sdk/client.py
+++ b/src/normlite/notion_sdk/client.py
@@ -204,6 +204,15 @@ class AbstractNotionClient(ABC):
         """
         return self._ischema_page_id 
 
+    def close(self) -> None:
+        """Release any resources held by this client.
+
+        The default implementation is a no-op. Subclasses with persistent
+        resources (e.g. open files) should override this method.
+
+        .. versionadded:: 0.10.0
+        """
+
     @abstractmethod
     def pages_create(
             self, 
@@ -1381,6 +1390,13 @@ class FileBasedNotionClient(InMemoryNotionClient):
             self.load()
         return self
         
+    def close(self) -> None:
+        """Flush the store to disk.
+
+        .. versionadded:: 0.10.0
+        """
+        self.flush()
+
     def __exit__(
         self,
         exctype: Optional[Type[BaseException]] = None,
@@ -1388,6 +1404,9 @@ class FileBasedNotionClient(InMemoryNotionClient):
         exctb: Optional[TracebackType] = None,
     ) -> Optional[bool]:
         """Dump the Notion stored to the file.
+
+        .. versionchanged:: 0.10.0
+            Delegates to :meth:`close` instead of calling :meth:`flush` directly.
 
         Args:
             exctype (Optional[Type[BaseException]]): The exception class. Defaults to ``None``.
@@ -1399,7 +1418,7 @@ class FileBasedNotionClient(InMemoryNotionClient):
         """
 
         if self._auto_flush:
-            self.flush()
+            self.close()
         return False  # never swallow exceptions
 
 #--------------------------------------------------

--- a/tests/unit/notion_sdk/test_notion_sdk_filebased_client.py
+++ b/tests/unit/notion_sdk/test_notion_sdk_filebased_client.py
@@ -237,3 +237,28 @@ def test_context_manager_respects_auto_flush_false(tmp_path):
 
     data = json.loads(path.read_text())
     assert "abc" not in data["objects"]
+
+
+# ----------------------------------------------------------------------
+# close()
+# ----------------------------------------------------------------------
+
+def test_close_flushes_store_to_disk(tmp_path):
+    path = tmp_path / "store.json"
+    client = FileBasedNotionClient(path, auto_load=False)
+
+    client._store["abc"] = {"object": "page", "id": "abc"}
+    client.close()
+
+    data = json.loads(path.read_text())
+    assert "abc" in data["objects"]
+
+
+def test_close_is_noop_when_read_only(tmp_path):
+    path = tmp_path / "store.json"
+    client = FileBasedNotionClient(path, read_only=True, auto_load=False)
+
+    client._store["abc"] = {"object": "page", "id": "abc"}
+    client.close()
+
+    assert not path.exists()

--- a/tests/unit/notion_sdk/test_notion_sdk_in_memory_client.py
+++ b/tests/unit/notion_sdk/test_notion_sdk_in_memory_client.py
@@ -1268,3 +1268,8 @@ def test_search_filter_value_not_a_page_or_database_raises(client):
 
 def test_deleted_pages_have_in_trash_true(client):
     pass
+
+def test_close_is_noop(client):
+    client._store["abc"] = {"object": "page", "id": "abc"}
+    client.close()
+    assert "abc" in client._store


### PR DESCRIPTION
## Summary

- Redesigns the CI/CD pipeline: automated `workflow_dispatch` release flow, tag re-pointing on PR merge, Sphinx docs deployment, and per-PR coverage comments
- Fixes `pyproject.toml` `testpaths` (was pointing to a non-existent path)
- Adds `close()` to `AbstractNotionClient` (no-op) and `FileBasedNotionClient` (delegates to `flush()`); refactors `__exit__` to call `close()`

## Test plan

- [ ] Merge this PR — verify `ci.yml` does NOT fire (it doesn't exist on `main` yet at merge time)
- [ ] Open a follow-up bug-fix PR — verify `ci.yml` triggers, tests pass, coverage comment appears
- [ ] Trigger `release.yml` from `main` — verify dry-run version extraction, release branch creation, `cz bump`, and PR opening
- [ ] Merge the release PR — verify `tag-and-deploy.yml` fires: tag re-points to merge commit, docs deploy to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)