### PR TITLE
fix: remove leftover pdb debug imports from production source

### DIFF
--- a/src/normlite/notion_sdk/client.py
+++ b/src/normlite/notion_sdk/client.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
-import pdb
 from typing import List, Optional, Self, Set, Type
 from types import TracebackType
 from abc import ABC, abstractmethod

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 from operator import itemgetter
-import pdb
 from typing import Any, Dict, Iterator, List, Literal, NoReturn, Optional, Self, Sequence, Tuple, TypeAlias, Union
 from itertools import islice
 import uuid


### PR DESCRIPTION
## Summary

- Removes `import pdb` from `src/normlite/notion_sdk/client.py` and `src/normlite/notiondbapi/dbapi2.py` — debugging artifacts with no production use.

## Test plan

- [ ] CI passes (this PR is the smoke test for the new `ci.yml` pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)