### PR TITLE
feat(engine): Engine.dispose() and file-based persistence (#294)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,6 +190,81 @@ non-truncating behaviour.
 
 ---
 
+## Engine Setup
+
+### root_page_id
+The Notion-side identifier of the top-most parent under which the engine's `information_schema`
+page and user databases are anchored. Every page/database in normlite needs a parent; this is the
+ultimate ancestor of the tree.
+
+The semantics differ by integration kind:
+- **Simulated integrations** (`InMemoryNotionClient`, `FileBasedNotionClient`): the client mints
+  its own synthetic root page (`_ROOT_PAGE_ID_`). The engine defaults
+  `self._root_page_id` to that constant when the user does not supply one. **Not required** from
+  `create_engine` callers.
+- **Real Notion integrations** (`normlite+auth://internal`, when implemented): the root must be a
+  real Notion workspace page the integration was granted access to. The client cannot invent it.
+  **Required** from `create_engine` callers, and validated at engine construction.
+
+Both memory- and file-mode simulated engines apply the same fallback symmetrically — `root_page_id`
+is never *required* for simulated URIs, only optional. An earlier inconsistency where file-mode
+demanded a user-supplied `root_page_id` was a latent bug; both simulated branches now share the
+"default to the client's `_ROOT_PAGE_ID_`" rule.
+
+---
+
+## Engine Lifecycle
+
+### Engine.dispose()
+Terminal disposal of an `Engine`. Releases backend resources by calling `self._client.close()`
+— a no-op for `InMemoryNotionClient` and a flush-to-disk for `FileBasedNotionClient`.
+After `dispose()` has been *called* (whether it returned cleanly or raised), the engine is
+**terminal**: `engine.connect()` and `engine.raw_connection()` raise
+`InvalidRequestError("Engine has been disposed")`. User-held `Connection` objects are not
+tracked; they fail at their next `execute()` because the path goes through
+`Engine.raw_connection()`.
+Idempotent: calling `dispose()` on an already-disposed engine is a silent no-op.
+Cascade is minimal — only `self._client` is closed; `self._dbapi_connection` and `self._catalog`
+hold no I/O state of their own and are not given a `close()` method.
+
+**Error handling.** `self._client.close()` is wrapped in `try / finally`. If close raises
+(e.g. `OSError` from a failed `FileBasedNotionClient.flush()`), the exception propagates
+unchanged and `self._is_disposed` is still flipped to `True` in the `finally` block. The
+engine cannot be reused or retried after a failed close — retry can't recover the partially
+written file anyway, and continuing to mutate an unsynced in-memory store is the worse trap.
+
+A read-only `engine.disposed` property exposes the state for tests and user code.
+
+**Context-manager support.** `Engine` implements `__enter__` / `__exit__`. `__enter__` returns
+`self`; `__exit__` calls `self.dispose()` unconditionally and returns `None` (never swallows
+exceptions). Idempotency keeps an explicit `engine.dispose()` inside a `with` block safe.
+Mirrors the CM idiom already present on `FileBasedNotionClient`.
+
+See [[adr-0003-engine-dispose-semantics]] for the architectural rationale.
+
+### read_only (engine kwarg)
+A flat top-level kwarg on `create_engine`, plumbed through `Engine.__init__(**kwargs)` to
+`FileBasedNotionClient(path, read_only=True)`. Enables test fixtures that read a saved
+store from disk without mutating the file on exit.
+Valid only for file-mode URIs; supplying `read_only=True` together with a `:memory:` URI raises
+`ArgumentError("read_only is only valid for file-based URIs")`.
+
+If `read_only=True` **and** `auto_load=True` (the default) are both supplied but the target file
+does not exist, `FileBasedNotionClient.__init__` raises
+`NotionError("Invalid request URL: <path>", status_code=400, code="invalid_request_url")`.
+This treats the file path as the client's effective request URL and mirrors Notion's real
+`invalid_request_url` error code. Rationale: the whole point of `read_only` + `auto_load` is to
+read an existing fixture; silently producing an empty in-memory store from a mistyped path turns
+the feature into a footgun.
+
+The gating is the **intersection** of both flags, not `read_only` alone — `read_only=True` +
+`auto_load=False` is a legitimate in-memory-scratchpad pattern (used internally by tests that
+exercise flush/close no-op semantics) and must continue to construct successfully against a
+missing path. The converse case (`read_only=False` + non-existent path) is also unchanged — it
+remains the "create a new file-backed engine" path regardless of `auto_load`.
+
+---
+
 ## DML Construct Decisions
 
 ### Update — partial VALUES

--- a/docs/adr/0003-engine-dispose-semantics.md
+++ b/docs/adr/0003-engine-dispose-semantics.md
@@ -1,0 +1,133 @@
+# ADR-0003: Engine.dispose() semantics
+
+**Status:** Accepted
+**Date:** 2026-05-19
+
+---
+
+## Context
+
+Issue #260 adds `Engine.dispose()` so users can release backend resources held by an
+`Engine` — most importantly, flush an `InMemoryNotionClient`-backed store to disk via
+`FileBasedNotionClient.close() → flush()`. The user-visible motivation in the issue
+body is the file-based persistence path:
+
+```python
+engine = create_engine("normlite:/path/to/database/file.db", root_page_id=...)
+# ... DDL/DML ...
+engine.dispose()
+```
+
+The naive reading of "dispose" leaves three load-bearing questions unanswered:
+
+1. **Post-dispose state** — is the engine still usable, or terminal?
+2. **Cascade depth** — does `dispose()` walk every component the engine holds
+   (`_dbapi_connection`, `_catalog`, user-held `Connection`s, `_client`), or only the
+   things that own real I/O state?
+3. **Error handling** — if `_client.close()` raises (e.g. `FileBasedNotionClient.flush()`
+   hits `PermissionError` or a full disk), does the engine remain "not yet disposed" so
+   the user can retry, or does it commit to the terminal state regardless?
+
+The shape of `dispose()` is locked in by the API exposed in v0.11.0. Changing any of the
+three decisions later would break user code that catches the post-dispose exception,
+relies on the cascade order, or expects retry-after-failure to be supported.
+
+## Decision
+
+**`Engine.dispose()` is terminal, has a minimal cascade, and flips the disposed flag
+in `finally` whether or not `_client.close()` raises.**
+
+```python
+def dispose(self) -> None:
+    if self._is_disposed:
+        return
+    try:
+        self._client.close()
+    finally:
+        self._is_disposed = True
+```
+
+Concrete consequences of the three sub-decisions:
+
+- **Terminal.** After `dispose()` has been *called* (regardless of whether it returned
+  or raised), the engine is dead. `Engine.connect()` and `Engine.raw_connection()` check
+  `self._is_disposed` and raise
+  `InvalidRequestError("Engine has been disposed")`. A read-only `engine.disposed`
+  property exposes the state. A second call to `dispose()` is a silent no-op.
+- **Minimal cascade.** Only `self._client.close()` is called. `self._dbapi_connection`
+  (a pure-Python object), `self._catalog` (a pure-Python object), and any user-held
+  `Connection` objects handed out by `engine.connect()` are not given `close()` methods
+  and are not tracked in a registry. Held-over `Connection`s fail at their next
+  `execute()` because the path runs through `Engine.raw_connection()` — the single
+  guard catches every realistic reuse path.
+- **Finally-flips-flag on close failure.** The `try / finally` lets the I/O exception
+  propagate to the caller unchanged *and* commits the engine to the terminal state.
+  No retry path is supported.
+
+## Alternatives Considered
+
+**A. Reusable engine (SQLAlchemy-style `dispose()`).**
+Rejected. SQLAlchemy's `Engine.dispose()` is "reset the pool, engine stays usable"
+because there is a connection pool to reset. Normlite has no pool — one `_client`,
+one `_dbapi_connection`, one `_catalog` per engine. "Reset to a fresh state" has no
+meaning here. Terminal semantics is also the contract that lets a future contributor
+add transactions, pooling, or background flushers without breaking users who got into
+the habit of "dispose then keep going."
+
+**B. Full cascade (`close()` on DBAPI Connection, SystemCatalog, user-held Connections).**
+Rejected. The only resource with real lifecycle is the client (file handle, persisted
+state). The other components are pure Python objects with no I/O of their own; adding
+no-op `close()` methods to them is YAGNI. A `WeakSet` registry of handed-out
+`Connection` objects adds bookkeeping that protects nothing — fail-on-next-use is just
+as effective, and arguably better because the user sees the error where they made the
+mistake, not silently at dispose time. Full cascade becomes the right design when there
+is transactional state, a pool, or async cleanup to coordinate — none of those exist
+yet.
+
+**C. Propagate exception, leave `_is_disposed = False` (retry-possible).**
+Rejected. Looks attractive ("the operation didn't succeed, so the engine isn't disposed")
+but is misleading in practice:
+1. `FileBasedNotionClient.flush()` opens the target file with mode `"w"` and `json.dump`s
+   into it. A mid-write failure has already truncated the previous on-disk content;
+   the data is gone. Retrying `dispose()` cannot recover anything.
+2. Leaving `_is_disposed = False` invites the user to keep mutating the in-memory store
+   after a failed flush. The store and the file are now permanently out of sync, and no
+   subsequent `dispose()` can repair that.
+3. It is inconsistent with how Python idiomatically handles close-time failures
+   (`file.close()`, sockets, `contextlib.closing`): the resource is *closed* even if
+   the final flush failed.
+
+The `try / finally` shape gives users the actionable I/O exception *and* the unambiguous
+state invariant "after dispose has been called, the engine is over."
+
+**D. New `EngineDisposedError` exception type.**
+Rejected. The existing `InvalidRequestError` in `normlite.exceptions` is documented as
+"raised when a normlite method or function cannot perform as requested" — that is
+exactly what "engine has been disposed" means. New typed exceptions earn their keep
+when callers need to discriminate them in `except` clauses; disposed-engine errors are
+almost always programming bugs, not runtime conditions you catch, so the typed-exception
+payoff is low. `InternalError` was considered and rejected too — it is part of the
+DBAPI exception family (database-internal error), and overloading it for engine-state
+errors muddles its DBAPI semantics.
+
+## Consequences
+
+- `Engine` gains a private `_is_disposed: bool = False` attribute, set in `__init__`,
+  flipped in `dispose()`'s `finally` block. Public `engine.disposed` property exposes it.
+- `Engine.connect()` and `Engine.raw_connection()` both raise `InvalidRequestError`
+  when `self._is_disposed`. No other public methods are guarded — calls that go through
+  the client (`find_table_metadata`, `inspect`, etc.) fail downstream at the client
+  layer, which is acceptable because the issue's user-facing path is
+  `engine.connect()`-driven.
+- `Engine.__enter__` / `Engine.__exit__` are added in the same slice. `__exit__` calls
+  `dispose()` unconditionally and returns `None` (never swallows exceptions).
+- Held-over `Connection` objects do not need any new state. Their next `execute()` reads
+  `self._engine.raw_connection()`, which checks `_is_disposed` on `Engine` and raises.
+- A future "engine pool" or "transactional engine" feature can introduce richer cascade
+  (DBAPI `Connection.close()`, transaction rollback on dispose, etc.) without breaking
+  the public contract established here: post-dispose use of `connect()` /
+  `raw_connection()` remains an `InvalidRequestError`.
+- Users wanting "flush without disposing" do not have an API for it. If a real use case
+  appears, a separate `engine.flush()` or `dispose(close=False)` can be added later
+  without breaking this contract — the addition would be non-breaking because the
+  default behaviour stays terminal.

--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -67,7 +67,8 @@ Here a quick example of how to use :class:`Engine` and :class:`Connection`.
 from __future__ import annotations
 from pathlib import Path
 import pdb
-from typing import Any, Mapping, Optional, Sequence, TypeAlias, TYPE_CHECKING, overload
+from types import TracebackType
+from typing import Any, Mapping, Optional, Self, Sequence, Type, TypeAlias, TYPE_CHECKING, overload
 from dataclasses import dataclass
 from typing import Optional, Literal, Union
 from urllib.parse import urlparse, parse_qs, unquote
@@ -76,9 +77,9 @@ from normlite.engine.cursor import CursorResult
 from normlite.engine.context import ExecutionContext, ExecutionStyle
 from normlite.engine.interfaces import _distill_params, IsolationLevel
 from normlite.engine.systemcatalog import SystemCatalog, SystemTablesEntry, TableState
-from normlite.exceptions import ArgumentError, ObjectNotExecutableError
+from normlite.exceptions import ArgumentError, InvalidRequestError, ObjectNotExecutableError
 from normlite.sql.reflection import ReflectedColumnInfo
-from normlite.notion_sdk.client import InMemoryNotionClient, NotionError
+from normlite.notion_sdk.client import FileBasedNotionClient, InMemoryNotionClient, NotionError
 from normlite.sql.compiler import NotionCompiler
 from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection, Cursor as DBAPICursor, Error, InternalError, ProgrammingError
 from normlite.utils import frozendict
@@ -498,6 +499,16 @@ class Engine:
             Renamed to make the intend clearer.
         """
 
+        self._read_only: bool = kwargs.get("read_only", False)
+        """Whether the integration's store is read_only.
+        
+        It applies to file based Notion simulated clients.
+
+        .. versionadded:: 0.11.0
+        """
+        if self._read_only and uri.mode == "memory":
+            raise ArgumentError("read_only is only valid for file-based URIs")
+        
         self._database: Optional[str] = None
         """The database name.
         
@@ -518,6 +529,13 @@ class Engine:
         """The information schema system catalog.
         
         .. versionadded:: 0.8.0
+        """
+
+        self._is_disposed: bool = False
+        """Whether this engine has been previously disposed.
+        
+        
+        .. versionadded:: 0.11.0
         """
 
         self._create_client(uri)
@@ -574,6 +592,25 @@ class Engine:
         """
         return self._execution_options
     
+    def dispose(self) -> None:
+        """Dispose this engine and closes the underlying client.
+        
+        Public API for engine disposal.
+
+        A disposed engine raises :exc:`normlite.execeptions.InvalidRequestError` if
+        :meth:`Engine.connect` is called.
+
+
+        .. versionadded:: 0.11.0.
+        """
+        if self._is_disposed:
+            return
+        
+        try:
+            self._client.close()
+        finally:
+            self._is_disposed = True
+
     @property
     def _tables_id(self) -> str:
         """Database id for the Notion database tables.
@@ -590,6 +627,17 @@ class Engine:
         """
         return self._catalog._user_tables_page_id
 
+    @property
+    def disposed(self) -> bool:
+        """Provide disposal status for this engine.
+        
+        This is the public API to inspect the disposal status of an engine.
+        
+
+        .. versionadded:: 0.11.0
+        """
+        return self._is_disposed
+
     # -------------------------------------------------
     # Client creation + bootstrap
     # -------------------------------------------------
@@ -598,20 +646,22 @@ class Engine:
         if uri.mode not in ("memory", "file"):
             raise NotImplementedError
 
-        self._client = InMemoryNotionClient()
-
         # Resolve database name
         if uri.mode == "memory":
+            self._client = InMemoryNotionClient()
             self._database = "memory"
             self._user_database_name = self._user_database_name or "memory"
-            self._root_page_id = self._root_page_id or self._client._ROOT_PAGE_ID_
         else:
+            self._client = FileBasedNotionClient(
+                uri.path, 
+                read_only=self._read_only
+            )
             self._database = Path(uri.file).stem
             self._user_database_name = (
                 self._user_database_name or self._database
             )
-            if not self._root_page_id:
-                raise ArgumentError("root_page_id is required for file-based engines")
+
+        self._root_page_id = self._root_page_id or self._client._ROOT_PAGE_ID_
 
         if uri.mode in ("memory", "file"):
             # root page is required for simulated clients
@@ -875,6 +925,27 @@ class Engine:
     # Public API
     # -------------------------------------------------
 
+    def __enter__(self) -> Self:
+        """Initialize the engine's resources.
+
+        When the context manager is entered, the Notion store is read in memory, if the corresponding
+        file existes. Otherwise, the store in memory is initialized with an empty list.
+
+        Returns:
+            Self: This instance as required by the context manager protocol.
+        """
+        return self
+    
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self.dispose()
+        return None
+
+
     def inspect(self) -> Inspector:
         """Return an inspector object.
 
@@ -886,11 +957,32 @@ class Engine:
         return Inspector(self)
     
     def connect(self) -> Connection:
-        """Procure a new :class:`Connection` object."""
+        """Procure a new :class:`Connection` object.
+
+        Raises:
+            InvalidRequestError: If the engine has been previously disposed with :meth:`Engine.dispose`.
+
+        Returns:
+            Connection: The new connection object.
+        """
+        if self._is_disposed:
+            raise InvalidRequestError("Engine has been disposed")
         return Connection(self)
 
     def raw_connection(self) -> DBAPIConnection:
-        """Provide the underlying DBAPI connection."""
+        """Provide the underlying DBAPI connection.
+
+        Raises:
+            InvalidRequestError: If the engine has been previously disposed with :meth:`Engine.dispose`.
+
+        Returns:
+            DBAPIConnection: The underlying DBAPI connection associated with this engine.
+
+        .. versionchanged:: 0.11.0
+        """
+        if self._is_disposed:
+            raise InvalidRequestError("Engine has been disposed")
+
         return self._dbapi_connection
     
     #----------------------------------------------------

--- a/src/normlite/engine/systemcatalog.py
+++ b/src/normlite/engine/systemcatalog.py
@@ -582,7 +582,8 @@ class SystemCatalog:
             table_name='tables',
             table_schema='information_schema',
             table_catalog=self._user_database_name,
-            table_id=self._tables_id 
+            table_id=self._tables_id,
+            if_not_exists=True          # IMPORTANT: This ensure idempotency, either create it or use it
         )
 
     def _delete_restore_table(

--- a/src/normlite/notion_sdk/client.py
+++ b/src/normlite/notion_sdk/client.py
@@ -1373,6 +1373,14 @@ class FileBasedNotionClient(InMemoryNotionClient):
 
         self._auto_flush = auto_flush
         """Automatic flush """
+
+        if self._auto_load and self._read_only and not self._path.exists():
+            raise NotionError(
+                f"Invalid request URL: {str(self._path)} not found",
+                status_code=400,
+                code="invalid_request_url"
+            )
+
         if self._auto_load:
             self.load()
 

--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -1,15 +1,17 @@
 from collections import namedtuple
+import json
 import pdb
 import pytest
 
-from normlite.engine.base import Engine, Inspector, NotionAuthURI, NotionURI, _parse_uri, NotionSimulatedURI, Connection
+from normlite.engine.base import Engine, Inspector, NotionAuthURI, NotionURI, _parse_uri, NotionSimulatedURI, Connection, create_engine
 from normlite.engine.systemcatalog import TableState
-from normlite.exceptions import ArgumentError
-from normlite.notion_sdk.client import InMemoryNotionClient
+from normlite.exceptions import ArgumentError, InvalidRequestError
+from normlite.notion_sdk.client import FileBasedNotionClient, InMemoryNotionClient
 from normlite.notion_sdk.getters import get_object_id, get_parent_id, get_property, get_rich_text_property_value, get_title
 from normlite.notiondbapi.dbapi2 import Cursor
+from normlite.sql.dml import insert, select
 from normlite.sql.reflection import ReflectedColumnInfo
-from normlite.sql.schema import MetaData, Table
+from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import Boolean, Number, String
 from tests.utils.assertions import assert_is_valid_uuid4, is_valid_uuid4
 from tests.utils.db_helpers import create_students_db
@@ -215,13 +217,194 @@ def test_engine_inspector_reflect_user_table(engine: Engine, inspector: Inspecto
     assert 'is_active' in students.c
     assert isinstance(students.c.is_active.type_, Boolean)
         
+# -----------------------------------------------
+# Engine disposal
+# -----------------------------------------------
+
+def test_connect_after_dispose_raises_invalid_request_error():
+    # Arrange: a freshly constructed in-memory engine that we then dispose
+    engine = create_engine("normlite:///:memory:")
+    engine.dispose()
+
+    # Act + Assert: any further attempt to obtain a Connection must be rejected
+    with pytest.raises(InvalidRequestError, match="Engine has been disposed"):
+        engine.connect()
 
 
+def test_raw_connection_after_dispose_raises_invalid_request_error():
+    # Arrange: a freshly constructed in-memory engine that we then dispose
+    engine = create_engine("normlite:///:memory:")
+    engine.dispose()
 
+    # Act + Assert: the lower-level DBAPI handle must also reject use after disposal
+    with pytest.raises(InvalidRequestError, match="Engine has been disposed"):
+        engine.raw_connection()
 
+def test_disposed_property_reflects_engine_lifecycle_state():
+    # Arrange: a freshly constructed in-memory engine
+    engine = create_engine("normlite:///:memory:")
 
+    # Assert (pre): a brand-new engine is not disposed
+    assert engine.disposed is False
 
+    # Act: dispose the engine
+    engine.dispose()
 
+    # Assert (post): the engine now reports itself as disposed
+    assert engine.disposed is True
 
+def test_dispose_calls_underlying_client_close(monkeypatch):
+    # Arrange: a freshly constructed in-memory engine
+    engine = create_engine("normlite:///:memory:")
 
+    # Instrument the engine's collaborator so we can observe the disposal-time interaction.
+    # InMemoryNotionClient.close() is a no-op, so without instrumentation the cascade
+    # would have no observable side effect — the acceptance criterion would be untestable.
+    close_calls = []
+    monkeypatch.setattr(
+        engine._client,
+        "close",
+        lambda: close_calls.append("called"),
+    )
 
+    # Act
+    engine.dispose()
+
+    # Assert: dispose() delegated termination to the client exactly once
+    assert close_calls == ["called"]
+
+def test_dispose_is_idempotent_and_does_not_double_call_close(monkeypatch):
+    # Arrange: a freshly constructed in-memory engine, with the client's close()
+    # instrumented so we can count invocations
+    engine = create_engine("normlite:///:memory:")
+    close_calls = []
+    monkeypatch.setattr(
+        engine._client,
+        "close",
+        lambda: close_calls.append("called"),
+    )
+
+    # Act: dispose twice in succession; the second call must not raise
+    engine.dispose()
+    engine.dispose()
+
+    # Assert: close() was delegated to the client exactly once across both dispose() calls,
+    # and the engine remains in its terminal state
+    assert close_calls == ["called"]
+    assert engine.disposed is True
+
+def test_dispose_marks_engine_terminal_even_when_client_close_raises(monkeypatch):
+    # Arrange: a freshly constructed in-memory engine whose client.close()
+    # will raise a real I/O error
+    engine = create_engine("normlite:///:memory:")
+
+    def failing_close():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(engine._client, "close", failing_close)
+
+    # Act + Assert (propagation): dispose() must surface the underlying I/O exception
+    # unchanged — no wrapping, no swallowing
+    with pytest.raises(OSError, match="disk full"):
+        engine.dispose()
+
+    # Assert (terminal-state invariant): even though close() raised, the engine has
+    # committed to its disposed state. "After dispose has been called, the engine is
+    # over" — whether it returned cleanly or not.
+    assert engine.disposed is True
+
+def test_with_block_disposes_engine_on_clean_exit():
+    # Arrange + Act: open the engine in a with-statement and let it exit cleanly
+    with create_engine("normlite:///:memory:") as engine:
+        # Inside the block, the `as` target points at a live engine — not yet disposed
+        assert engine.disposed is False
+
+    # After the with-block exits, the engine is in its terminal state
+    assert engine.disposed is True
+
+def test_with_block_propagates_exception_and_still_disposes_engine():
+    # Act + Assert (propagation): the RuntimeError raised inside the inner with-block
+    # must escape — the context manager must not swallow it
+    with pytest.raises(RuntimeError, match="boom"):
+        with create_engine("normlite:///:memory:") as engine:
+            raise RuntimeError("boom")
+
+    # Assert (cleanup-on-error): even though the block exited via an exception,
+    # __exit__ disposed the engine
+    assert engine.disposed is True
+
+def test_create_engine_with_file_uri_constructs_file_based_client(tmp_path):
+    # Arrange: a file URI pointing into a per-test tmp directory.
+    # The path does not need to pre-exist — without read_only=True, the create-new
+    # path is legitimate (see slice #296).
+    store_path = tmp_path / "store.json"
+    file_uri = f"normlite:{store_path}"
+
+    # Act: build the engine. root_page_id is required for file URIs (existing contract).
+    engine = create_engine(file_uri)
+
+    # Assert: the engine constructed a file-backed client...
+    assert isinstance(engine._client, FileBasedNotionClient)
+
+    # ...and the client points at the path encoded in the URI.
+    assert engine._client._path == store_path
+
+def test_create_engine_rejects_read_only_with_memory_uri():
+    # Act + Assert: read_only is meaningless against a :memory: URI — there is no
+    # file to read from and no file to protect from writes — so the engine must
+    # reject the misuse at construction time.
+    with pytest.raises(ArgumentError, match="read_only is only valid for file-based URIs"):
+        create_engine("normlite:///:memory:", read_only=True)
+
+def test_create_engine_passes_read_only_through_to_file_based_client(tmp_path):
+    # Arrange: a minimal valid store on disk. With read_only=True and the default
+    # auto_load=True, the client requires the file to exist (slice #296's check),
+    # so we seed an empty-but-versioned store.
+    store_path = tmp_path / "fixture.json"
+    store_path.write_text(json.dumps({"version": 1, "objects": {}}))
+    file_uri = f"normlite:{store_path}"
+
+    # Act: build the engine with read_only=True
+    engine = create_engine(file_uri, read_only=True)
+
+    # Assert: the kwarg traveled all the way through Engine.__init__ and
+    # _create_client into the FileBasedNotionClient constructor.
+    assert isinstance(engine._client, FileBasedNotionClient)
+    assert engine._client._read_only is True
+
+def test_file_engine_round_trip_persists_data_and_preserves_file_under_read_only(tmp_path):
+    # Arrange: a file URI pointing into tmp_path; the file does not yet exist
+    store_path = tmp_path / "store.json"
+    file_uri = f"normlite:{store_path}"
+
+    # --- Phase 1: write a row through a file-backed engine ---
+    with create_engine(file_uri) as engine:
+        metadata = MetaData()
+        students = Table(
+            "students",
+            metadata,
+            Column("name", String(is_title=True)),
+        )
+        metadata.create_all(engine)
+        with engine.connect() as connection:
+            connection.execute(insert(students).values(name="Galileo"))
+
+    # After the write block exits, the store has been flushed to disk
+    assert store_path.exists()
+    bytes_after_write = store_path.read_bytes()
+
+    # --- Phase 2: reopen read-only, REFLECT the table (no writes), query ---
+    with create_engine(file_uri, read_only=True) as engine:
+        metadata = MetaData()
+        students = Table("students", metadata)                 # empty — reflection fills it
+        engine.inspect().reflect_table(students)
+        with engine.connect() as connection:
+            result = connection.execute(select(students))
+            rows = result.all()
+
+    # The inserted row survived the dispose → reopen round-trip
+    assert len(rows) == 1
+    assert rows[0].name == "Galileo"
+
+    # The read-only session did not modify the file on disk
+    assert store_path.read_bytes() == bytes_after_write

--- a/tests/unit/engine/test_syscat.py
+++ b/tests/unit/engine/test_syscat.py
@@ -428,3 +428,7 @@ def test_search_does_not_match_exactly_titles(
 
     assert state is TableState.MISSING
 
+def test_bootstrap_is_idempotent(engine: Engine):
+    catalog = SystemCatalog(engine._client, "db", engine._root_page_id, "db")
+    catalog.bootstrap()
+    catalog.bootstrap()  # must not raise

--- a/tests/unit/notion_sdk/test_notion_sdk_filebased_client.py
+++ b/tests/unit/notion_sdk/test_notion_sdk_filebased_client.py
@@ -262,3 +262,22 @@ def test_close_is_noop_when_read_only(tmp_path):
     client.close()
 
     assert not path.exists()
+
+def test_file_based_client_rejects_missing_path_in_read_only_mode(tmp_path):
+    # Arrange: a file path inside tmp_path that we deliberately never create
+    missing_path = tmp_path / "does-not-exist.json"
+    assert not missing_path.exists()  # sanity check on the fixture
+
+    # Act + Assert: construction must fail immediately — no broken-state client
+    with pytest.raises(NotionError) as exc_info:
+        FileBasedNotionClient(str(missing_path), read_only=True)
+
+    # The exception must carry Notion's `invalid_request_url` vocabulary so callers
+    # (and downstream tests that catch on .code) can react to it the same way they
+    # would to a real Notion error.
+    exc = exc_info.value
+    assert exc.status_code == 400
+    assert exc.code == "invalid_request_url"
+
+    # The message must include the offending path so the user can act on it.
+    assert str(missing_path) in exc.message


### PR DESCRIPTION
## Summary

- Ships PRD #294: terminal `Engine.dispose()` + idempotency + `try/finally`; engine context manager; file-mode URI wiring (`FileBasedNotionClient`); flat `read_only` kwarg on `create_engine` with cross-URI validation; missing-file validation on the client; end-to-end round-trip vertical proving write → dispose → reopen-read-only → query → on-disk byte-equality.
- Fixes a latent `SystemCatalog` bootstrap non-idempotency that the round-trip test surfaced (`_ensure_sys_tables_self_row` now passes `if_not_exists=True`), with a targeted regression test in `test_syscat.py`.
- Restores `root_page_id` symmetry across simulated URI modes — the file branch no longer demands a user-supplied `root_page_id`; both memory and file modes default to the client's synthetic `_ROOT_PAGE_ID_`. The previous file-mode "required" check was a latent bug, not a designed precondition.
- Architectural rationale in ADR-0003 (`docs/adr/0003-engine-dispose-semantics.md`); user-facing contracts in CONTEXT.md ("Engine Setup", "Engine Lifecycle" sections).

## Test plan

- [x] `uv run pytest tests/unit/engine/test_engine.py` — `Engine.dispose()`, context manager, file-mode wiring, `read_only` kwarg + memory-URI validation, end-to-end round-trip vertical.
- [x] `uv run pytest tests/unit/notion_sdk/test_notion_sdk_filebased_client.py` — `read_only` + missing-file validation; pre-existing flush/close/clear no-op semantics still green.
- [x] `uv run pytest tests/unit/engine/test_syscat.py` — `SystemCatalog.bootstrap()` idempotency regression guard.
- [x] `uv run pytest tests/unit/` — full unit suite (637 tests).
- [x] Skim CONTEXT.md "Engine Setup" and "Engine Lifecycle" sections; confirm the documented contracts match expectations.
- [x] Skim ADR-0003 "Alternatives Considered"; confirm the rejected design paths read coherently.

Closes #294
Closes #295
Closes #296
Closes #297
Closes #298
Closes #299
Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)