### PR TITLE
feat(sql): Select.join() — inner/outer joins, FK auto-detect, WHERE/ORDER BY routing (#302)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,6 +33,26 @@ Translates a DML/DDL AST into a `compiled_dict` — a JSON-like dict with keys `
 `path_params`, `payload`, and (for UPDATE) `update_payload`. Named placeholders (`:param`) are
 resolved at execution time by `ExecutionContext`.
 
+### Compiler entry points: `.compile()` vs `._compiler_dispatch()`
+Every `ClauseElement` exposes two compilation entry points with **different lifecycle
+semantics**. Confusing them is a real footgun.
+
+- **`.compile(compiler)`** — public, top-level entry. **Resets `compiler._compiler_state`
+  to a fresh `CompilerState()`** before dispatch, and wraps the result in a `Compiled`
+  (or `DDLCompiled`) object. Use this only when compiling a *statement* from outside
+  the compiler (e.g. `stmt.compile(NotionCompiler())` in tests, or from
+  `Connection._execute_context`).
+- **`._compiler_dispatch(compiler)`** — internal, recursive visitor dispatch.
+  **Preserves `_compiler_state`** and returns the raw dict produced by the matching
+  `visit_*` method. Use this from any `visit_*` method when descending into sub-nodes
+  (`whereclause`, `order_by` clauses, `joins`, expressions).
+
+**The trap**: calling `.compile()` from inside a `visit_*` method (e.g.
+`[j.compile(self) for j in select._joins]`) silently clobbers the in-flight
+`_compiler_state` for every sub-node and leaves `_compiler_state.stmt = None` by the
+time the outer `visit_select` returns. Use `_compiler_dispatch` for sub-node descent;
+reserve `compile` for the outermost call.
+
 ### Execution Pipeline
 The sequence: compile → `pre_exec` (bind params) → `_setup_execution` (Notion API call(s)) →
 `_execute_*` → `post_exec` → `_finalize_execution` (cursor routing).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -204,9 +204,11 @@ errors. See [[adr-0002-fake-client-lax-fk-validation]].
 **Deferred — `has_more` truncation.** Real Notion truncates relation property arrays past
 ~25 entries on page retrieval and exposes `has_more: true` with a separate
 `properties_retrieve` pagination endpoint. The fake currently returns the full list with
-no truncation. This is a known divergence to revisit when `Select.join()` is implemented;
-joins that paginate large relations in production must not silently rely on the fake's
-non-truncating behaviour.
+no truncation. `Select.join()` v1 (PRD #302) ships **against in-memory clients only**, so
+this divergence is deferred **until a real Notion integration is built** — not resolved by
+the join work. Joins that paginate large relations in production must not silently rely on
+the fake's non-truncating behaviour. See [[adr-0007-join-dangling-fk-propagation]] for the
+shipped join FK-resolution contract and PRD #302 for the integration deferral.
 
 ---
 

--- a/docs/adr/0002-fake-client-lax-fk-validation.md
+++ b/docs/adr/0002-fake-client-lax-fk-validation.md
@@ -20,7 +20,13 @@ levels of validation are plausible for the fake at `pages_create` / `pages_updat
    store and that its parent database matches the relation's declared `database_id`.
 
 This decision shapes how dangling-FK bugs surface in tests built on top of the fake, and
-sets the boundary the upcoming `Select.join()` work will be tested against.
+set the boundary the `Select.join()` work was tested against. That work has since shipped
+(slices 4–7, #306–#309): the lax-FK contract below is what makes a dangling reference
+resolve to "no matching right row" at join time. How that propagates — silently dropped by
+an inner join, preserved as a None-filled phantom by an outer join — is fixed in
+[ADR-0007](./0007-join-dangling-fk-propagation.md), and the predicate-against-a-phantom
+rule in [ADR-0005](./0005-outer-join-phantom-null-semantics.md). The joined result-set
+shape is fixed in [ADR-0006](./0006-join-result-row-shape.md).
 
 ## Decision
 

--- a/docs/adr/0004-expression-hierarchy-modifier-vs-column.md
+++ b/docs/adr/0004-expression-hierarchy-modifier-vs-column.md
@@ -1,0 +1,106 @@
+# ADR-0004: Expression hierarchy — `ModifierExpression` stays a `ClauseElement` sibling, not a `ColumnElement`
+
+**Status:** Accepted
+**Date:** 2026-06-01
+
+---
+
+## Context
+
+Slice 5 of `Select.join()` (#307) introduced source-table *routing*: a WHERE or ORDER BY
+expression that touches only the left (driving) table rides into the phase-1
+`databases.query` payload (`filter` / `sorts`); anything touching the right table is held
+out of phase-1 and answered client-side after the join.
+
+Both routing sites share one helper in `compiler.py`:
+
+```python
+def _get_expression_parent_tables(expression: ClauseElement) -> Set[Table]:
+    # recursive fold: Column leaf -> {parent}; Binary/Unary/BooleanClauseList recurse;
+    # OrderByClause/OrderByExpression recurse.
+```
+
+The fold returns the **set** of tables an expression touches, and each site routes on
+`parent_tables == {select._table}`.
+
+While extending the fold from WHERE to ORDER BY, an asymmetry in the expression hierarchy
+surfaced (`src/normlite/sql/elements.py`):
+
+- `ColumnElement(ClauseElement)` is the base for column expressions:
+  `UnaryExpression`, `BinaryExpression`, `BooleanClauseList`, `BindParameter`. It defines
+  an **operator interface** — `__and__`/`__or__` (build `BooleanClauseList`), `__invert__`
+  (build `UnaryExpression`), `__bool__` (raise), plus `name`, `type_`, `primary_key`, and
+  the comparator protocol.
+- `ModifierExpression(ClauseElement)` is a **sibling** of `ColumnElement`, not a subclass.
+  `OrderByExpression(ModifierExpression)` wraps a `(column, direction)` pair.
+
+Because one fold now spans both families, its only common supertype is `ClauseElement`, so
+the parameter annotation had to widen from `ColumnElement` to `ClauseElement`. This prompted
+a proposal to "fix" the asymmetry by making `ModifierExpression` derive from `ColumnElement`
+so the annotation could narrow back.
+
+## Decision
+
+**`ModifierExpression` remains a `ClauseElement` sibling of `ColumnElement`. We do not
+re-parent it under `ColumnElement`, and we do not add a `parent` attribute to
+`ColumnElement`.**
+
+Two principles drive this:
+
+1. **A statement modifier is not a column expression.** `ColumnElement` is an interface,
+   not a tag. Re-parenting `ModifierExpression` under it would hand every ORDER BY node
+   `__and__`/`__or__`/`__invert__`/`__bool__`, a comparator protocol, `type_`, and `name` —
+   none of which an ORDER BY node can honor (`courses.c.title.asc() & ...` is nonsense).
+   That is a Liskov/ISP violation: widening the *interface* to narrow a *type annotation*.
+   The one-word annotation (`ClauseElement`) is honest about the surface; the inheritance
+   would be a lie.
+
+2. **`ColumnElement` correctly has no `parent`.** A non-leaf expression such as
+   `students.c.name == "x" AND courses.c.title == "y"` does not *have* a parent table — it
+   touches a **set** of them. That is exactly why the router returns `Set[Table]`. Only the
+   `Column` leaf has a single well-defined `parent`. Adding `parent` to `ColumnElement` would
+   force a single-table answer for multi-table nodes — reintroducing the very mis-routing the
+   slice exists to prevent. The recursion that walks down to `Column` leaves is the natural
+   shape of folding a tree-with-many-leaves into a set, not a workaround for a missing field.
+   The `OrderByExpression -> .column` hop is likewise intrinsic: the wrapper carries the
+   sort direction and cannot be collapsed without losing it.
+
+The real (minor) smell is that **one fold straddles two node families**. The preferred
+remedy — deferred to a dedicated refactor slice, not bolted onto #307 — is to keep the fold
+narrow (`_get_expression_parent_tables(expr: ColumnElement)`, column expressions only) and
+**unwrap `OrderByExpression.column` at the ORDER BY routing call site** before folding. The
+modifier-specific knowledge ("an ORDER BY clause is a list of `(column, direction)` pairs")
+then lives at the call site where it belongs, the annotation returns to `ColumnElement`, and
+no class hierarchy changes.
+
+## Alternatives Considered
+
+**A. Re-parent `ModifierExpression` under `ColumnElement`.**
+Rejected. Cures the annotation symptom by giving modifiers a column-expression interface they
+cannot satisfy — a strictly worse smell (LSP/ISP violation) than a widened type hint.
+
+**B. Add a `parent` attribute to `ColumnElement`.**
+Rejected. Ambiguous/undefined for any multi-table node; would force the router to pick one
+table and silently mis-route compound predicates.
+
+**C. Call-site unwrap, keep the fold on `ColumnElement` (preferred, deferred).**
+Accepted in principle, deferred in time. Keeps the fold pure and column-only, restores the
+tighter annotation, and changes no hierarchy. Out of scope for #307; consistent with the
+project's "prefer existing patterns, defer refactors to dedicated slices" discipline.
+
+## Consequences
+
+- For now, `_get_expression_parent_tables` is annotated `ClauseElement` and contains
+  `OrderByClause`/`OrderByExpression` branches alongside the column-expression branches.
+  This is accepted interim coupling, not the target shape.
+- The expression hierarchy keeps a clean conceptual split: `ColumnElement` = things that
+  participate in column-level boolean/comparison algebra; `ModifierExpression` = statement
+  modifiers that *carry* columns. New modifier kinds (e.g. LIMIT/OFFSET-style nodes) extend
+  `ModifierExpression`, not `ColumnElement`.
+- When the call-site-unwrap refactor (Alternative C) is scheduled, it must remove the
+  `OrderByClause`/`OrderByExpression` branches from the fold and re-narrow the annotation;
+  the two routing sites stay symmetric ("collect tables from the columns, route on
+  `== {left}`").
+- Unrecognized nodes still contribute no tables; the top-level guard in `visit_select`
+  raises `CompileError` only for a fully-unattributable expression. A new node type that is
+  routable must extend the fold (or its call-site unwrap) or it routes silently.

--- a/docs/adr/0005-outer-join-phantom-null-semantics.md
+++ b/docs/adr/0005-outer-join-phantom-null-semantics.md
@@ -1,0 +1,128 @@
+# ADR-0005: Outer-join phantom rows obey SQL NULL semantics, not Notion empty-property semantics
+
+**Status:** Accepted
+**Date:** 2026-06-06
+
+---
+
+## Context
+
+`Select.outerjoin(...)` preserves a left row that matched zero right rows by emitting a
+single **phantom row**: the left columns carry real values, every right column is
+None-filled (`merge_inner_join_rows` / `_project_join_row` in `sql/dml.py`). Phantoms are
+common because the fake client validates relation *shape* but not FK *targets*
+([ADR-0002](./0002-fake-client-lax-fk-validation.md)), so dangling references resolve to
+"no matching right row" rather than an error.
+
+Slice 5 (#307) routes a right-side `WHERE` predicate *out* of the phase-1
+`databases.query` (the phantom is fabricated client-side and never exists in the right
+database, so no server query can see it). Slice 6 (#308) must therefore answer the
+right-side predicate **client-side, after the merge** — which forces a decision about what
+a right-side predicate *means* when evaluated against a phantom.
+
+Two empty-value models collide at this exact point:
+
+1. **SQL NULL + three-valued logic.** An outer join's unmatched right columns are NULL.
+   Any predicate on a NULL operand evaluates to UNKNOWN, and `WHERE` keeps only rows that
+   are TRUE — so a right-side predicate drops the phantom. This is *type-independent*: NULL
+   poisons `title`, `number`, `date`, `checkbox` identically.
+
+2. **Notion empty-property.** Notion has **no NULL**. Every property has a concrete empty
+   shape (`[]` for `title`/`rich_text`/`relation`, absent/`{}` for `date`) and Notion's own
+   `is_empty` / `is_not_empty` operate on those concrete shapes. There is no honest empty
+   representation for some types: a **checkbox is never empty** (always concretely
+   `true`/`false`, default `false`), and the fake's `number` filter exposes no `is_empty`
+   operator at all.
+
+The first implementation attempt took model (2): a per-type `empty_value` table mapped each
+None-filled cell to a fabricated Notion-empty shape, rebuilt a page, and fed it to the
+fake's `_Filter` (`notion_sdk/client.py`). This works for `title`/`rich_text`/`relation`
+(their empty shapes make `is_not_empty` → False) and *accidentally* for `date` (the
+sentinel is rejected by `normalize_page_date`'s `isinstance(_, dict)` guard → None). It
+**fails** for the other two:
+
+- **number** — `EMPTY_NUMBER` (an `_EmptyType` sentinel) flows unguarded into
+  `number.greater_than` / `number.less_than` (`lambda a, b: a > b`) and raises `TypeError`.
+  The comparison lambdas have no empty-guard, unlike `title`/`rich_text` which already do
+  (`False if a is EMPTY_TEXT else ...`).
+- **checkbox** — `EMPTY_CHECKBOX` under `does_not_equal True` evaluates
+  `EMPTY_CHECKBOX is not True` → **True**, so the phantom is **kept**. SQL says `NULL != True`
+  is UNKNOWN → drop. Fabricating an empty checkbox invents a value Notion never has and
+  produces the wrong answer.
+
+## Decision
+
+**A right-side predicate on an outer join is answered with SQL NULL semantics. A phantom
+fails every right-side predicate by construction, decided structurally — not by
+fabricating per-type Notion-empty values.**
+
+- In the post-merge filter (`_right_side_passes` in `sql/dml.py`), a merged row whose right
+  slice is entirely None-filled **is** the phantom and is dropped without building a page or
+  invoking `_Filter`:
+
+  ```python
+  right_slice = merged_row[left_width:]
+  if all(c is None for c in right_slice):
+      return False          # phantom: NULL fails every right-side predicate
+  # else: real right row, concrete on-wire shapes — hand to _Filter unchanged
+  ```
+
+- This rests on the invariant that **a Python `None` cell in a merged tuple originates only
+  from the phantom None-fill** — real right rows carry concrete on-wire dicts
+  (`{"title": []}`, `{"checkbox": false}`), never `None`. So `all(None)` ⟺ phantom ⟺
+  "right entity absent" ⟺ drop. This invariant must be pinned by a test so a future
+  result-processor that emits `None` for a present-but-empty property cannot silently
+  re-classify a real row as a phantom.
+
+- The per-type `empty_value` table and the `if cell is None` page-rebuild branch are
+  **removed**. No empty values are fabricated. Only genuine right rows reach `_Filter`,
+  with their real shapes, so the existing `_Filter` evaluation path is untouched.
+
+This keeps the engine's reliance on the underscore-private `_Filter` confined to genuine
+right rows, respecting the boundary flagged for a future shared-evaluator decision.
+
+## Alternatives Considered
+
+**A. Harden `_Filter`'s operator lambdas to treat `EMPTY_*` sentinels as NULL-like.**
+Guard every comparison (`number.greater_than: lambda a, b: False if a is EMPTY_NUMBER else
+a > b`; `checkbox.does_not_equal: False if a is EMPTY_CHECKBOX else a is not b`) so empties
+poison predicates to False uniformly, mirroring the `EMPTY_TEXT` guards `title`/`rich_text`
+already carry. **Deferred, not rejected** — but as a *separate* concern. The `number`
+comparison `TypeError` is a pre-existing latent bug in the fake's own `databases.query`
+(an empty number compared server-side crashes today, join or no join). Fixing it belongs to
+its own slice with a red test against `databases.query` directly, and touches the shared
+`_Filter` evaluator — which is ADR-worthy in its own right (see Consequences). Folding it
+into the join slice would couple two unrelated decisions and pull the engine deeper into
+underscore-private SDK internals.
+
+**B. Fabricate per-type Notion-empty values (the first attempt).**
+Rejected. It reconstructs model (2) to answer a model (1) question, invents values Notion
+never has (empty checkbox), crashes for number, and works for date only by accident. It
+also makes correctness *type-dependent* when the underlying semantics (NULL poisons
+everything) are type-independent — so every new right-column type would need a new, easily
+wrong, table entry.
+
+**C. Pre-filter raw right pages before the merge.**
+Rejected. Pre-filtering keeps phantoms (their None-fill is fabricated *after* the merge),
+giving the wrong answer — which is the whole reason slice 5 routed the right-side predicate
+out of phase-1 first. The predicate must be applied **post-merge**.
+
+## Consequences
+
+- `_right_side_passes` becomes type-independent and shrinks: no `empty_value` /
+  `type_mapper` empty branch, no fabricated page for phantoms. The phantom drop is one
+  `all(... is None)` check.
+- A new invariant — "`None` in a merged tuple ⟺ phantom" — becomes load-bearing and must be
+  guarded by a test. If a future `result_processor` emits Python `None` for a present
+  property, that test fails loudly instead of the join silently dropping a real row.
+- `is_empty` on a right column now distinguishes **absent entity** (phantom → UNKNOWN →
+  drop) from **present entity with an empty property** (real row → `_Filter` → may match).
+  These land on opposite sides of `is_empty`, matching SQL. Worth an explicit test.
+- The fake's `_Filter` still cannot evaluate a comparison against a genuinely-empty
+  `number` without `TypeError`, and treats checkbox/number empties inconsistently. That
+  debt is now *named and isolated* (Alternative A) rather than hidden inside the join. A
+  follow-up ADR should decide whether to promote `_Filter` to a shared, backend-agnostic
+  evaluator with documented NULL/empty semantics before the engine leans on it further.
+- Real Notion filters server-side and never sees a phantom; this decision only governs the
+  client-side post-merge step that the outer join introduces, so it does not drift from
+  real-API behaviour for genuine rows.

--- a/docs/adr/0005-outer-join-phantom-null-semantics.md
+++ b/docs/adr/0005-outer-join-phantom-null-semantics.md
@@ -67,6 +67,14 @@ fabricating per-type Notion-empty values.**
   # else: real right row, concrete on-wire shapes — hand to _Filter unchanged
   ```
 
+  > **Update (2026-06-13, #309).** The right slice is no longer extracted via
+  > `merged_row[left_width:]`; that count-from-the-full-left-schema slice broke under a
+  > narrowed projection. It is now built from joined-schema getters
+  > (`merged_schema.column_getter(name)`, in projection order) — see
+  > [ADR-0006](./0006-join-result-row-shape.md). **The decision in this ADR is unchanged:**
+  > the all-None right slice still *is* the phantom and is still dropped structurally before
+  > `_Filter` is invoked.
+
 - This rests on the invariant that **a Python `None` cell in a merged tuple originates only
   from the phantom None-fill** — real right rows carry concrete on-wire dicts
   (`{"title": []}`, `{"checkbox": false}`), never `None`. So `all(None)` ⟺ phantom ⟺

--- a/docs/adr/0006-join-result-row-shape.md
+++ b/docs/adr/0006-join-result-row-shape.md
@@ -1,0 +1,91 @@
+# ADR-0006: Join result row-shape — flat rows, projection narrowing, qualified names on collision
+
+**Status:** Accepted
+**Date:** 2026-06-13
+
+---
+
+## Context
+
+`Select.join(...)` / `Select.outerjoin(...)` produce a result set that spans **two**
+tables. Three shape questions had to be settled before the result-set contract could be
+called stable (PRD #302, user stories 7 & 8; slice 7 / #309):
+
+1. **Structure** — does a joined row nest the two sides (`{left: {...}, right: {...}}`) or
+   flatten them into one tuple?
+2. **Projection** — when the user names a subset of columns
+   (`select(students.c.name, courses.c.title)`), does the result still carry every property
+   of both tables, or only the named ones?
+3. **Naming collisions** — when both tables expose a column of the same name
+   (`students.name`, `instructors.name`), how is each surfaced through `keys()` /
+   `mappings()` without one silently shadowing the other?
+
+These decisions feed the existing `Row` metadata machinery (`SchemaInfo`, `keys()`,
+`mappings()`), which until the join work assumed a single source table.
+
+## Decision
+
+**A joined row is a flat tuple of result columns in deterministic projection order.
+Projection narrows both the result set and the phase-1 payload. Colliding names are
+qualified — but only the colliding ones.**
+
+- **Flat rows.** A merged row is `(left user cols…, right user cols…)` in projection order,
+  not a nested structure. The left side precedes the right side; both follow the order in
+  which their columns appear in the projection (`SchemaInfo.from_join`, `_project_join_row`
+  in `sql/dml.py`). This keeps `Row` positional access and `mappings()` uniform with the
+  single-table case.
+
+- **Projection narrowing.** `select(students.c.name, courses.c.title)` projects **only** the
+  named columns. The narrowing is also pushed to the phase-1 `databases.query` via
+  `filter_properties`, so the wire payload carries only the projected left-side **properties**
+  — with two non-negotiable carve-outs:
+  - `object_id` is **not** a property and must never go in `filter_properties` (the
+    in-memory client rejects it as `NotionError`); it rides in `execution_names` instead.
+  - the join **onclause** column (the relation FK) is an *execution requirement* and must
+    survive **inside** `filter_properties` even when the user did not project it, because
+    phase-2 needs it to resolve the right side. These two pull in opposite directions and
+    must not be conflated.
+
+- **Qualified names on collision — only the colliding ones.** `SchemaInfo.from_join` groups
+  the projected entities by bare name; any name that appears more than once in the
+  projection is qualified as `"<parent-table>.<name>"` for **every** entity that carries it
+  (so both `students.name` and `instructors.name` surface, neither shadows the other).
+  Names that do not collide keep their bare form. A plain single-table `select(students)` is
+  untouched — qualification fires only inside a join with an actual collision. Qualification
+  uses the table's public `name`, never an internal/execution name.
+
+## Alternatives Considered
+
+**A. Nested rows (`row.left.name`, `row.right.title`).**
+Rejected. It forks the `Row`/`mappings()` contract between single-table and join results,
+breaks positional access, and pushes disambiguation onto every consumer. Flat rows with
+conditional qualification keep one row model.
+
+**B. Always qualify every column in a join.**
+Rejected. It regresses the single-table-shaped contract for joins with no collision
+(`select(students, courses)` would suddenly key `students.name` / `courses.title`), breaking
+existing `keys()` expectations for no benefit. Qualification is a collision-resolution tool,
+not a default.
+
+**C. Project all properties regardless of the column list.**
+Rejected. It defeats the point of a narrow projection (story 7), pulls every property over
+the wire, and makes `filter_properties` dead weight.
+
+## Consequences
+
+- `SchemaInfo` is the single source of truth for the joined result shape: ordering,
+  narrowing, and qualified keys all flow from it. `keys()` and `mappings()` surface the
+  qualified keys on collision with no shadowing.
+- The merged-column order is deterministic (projection order, left before right), so
+  repeated runs and `mappings()` lookups are stable.
+- **Known limitation — right-side `WHERE` on a colliding column is unsupported in v1.** The
+  post-merge right-side filter looks its getters up by the bare right-table column name,
+  while a colliding right column is keyed fully-qualified in the joined schema — so a
+  `WHERE` on that exact column is silently ignored, or (if it is the only projected right
+  column) drops every row via the all-None phantom guard. Workaround: qualify or rename.
+  A real fix must look the getter up by the joined (qualified) name and needs its own slice
+  with a red test. See issue #309 / #310 discussion. The all-None phantom-drop rule
+  ([ADR-0005](./0005-outer-join-phantom-null-semantics.md)) is unaffected.
+- Filtering on a **non-projected** right column is likewise unreconstructable from the merged
+  tuple and is out of scope here (it needs evaluation against the raw phase-2 page).
+- `SchemaInfo.from_join` does not yet compose `from_table`; that consolidation is deferred.

--- a/docs/adr/0007-join-dangling-fk-propagation.md
+++ b/docs/adr/0007-join-dangling-fk-propagation.md
@@ -1,0 +1,69 @@
+# ADR-0007: Inner- vs outer-join propagation of dangling foreign keys
+
+**Status:** Accepted
+**Date:** 2026-06-13
+
+---
+
+## Context
+
+The fake client validates relation *shape* but not FK *targets*
+([ADR-0002](./0002-fake-client-lax-fk-validation.md)), mirroring real Notion's lazy
+reference semantics: a relation property may hold a page ID that points at no existing page
+(a **dangling reference**). `Select.join()` resolves the right side in phase 2 by looking up
+those IDs, so it must define what happens to a left row whose relation resolves to **zero**
+right rows — and that answer differs between inner and outer joins (PRD #302; slices 4–6,
+#306–#308).
+
+This is distinct from the *row-shape* decision ([ADR-0006](./0006-join-result-row-shape.md))
+and from the *predicate-against-a-phantom* decision
+([ADR-0005](./0005-outer-join-phantom-null-semantics.md)); this ADR fixes only the
+**cardinality contract** — which left rows survive.
+
+## Decision
+
+**An inner join drops a left row with no matching right row; an outer join preserves it as a
+single None-filled phantom.**
+
+- **Inner join (`.join`).** A left row whose relation targets no existing right page is
+  **silently dropped** — no error, no placeholder. A dangling reference and a genuinely
+  empty relation are indistinguishable at the cardinality level, and both yield "no pair."
+  This matches ADR-0002: invalid IDs surface as empty results, not failures.
+
+- **Outer join (`.outerjoin`).** The same left row **survives** as one phantom row: left
+  columns carry real values, every right column is `None`
+  (`merge_inner_join_rows` / `_project_join_row`, `isouter=True`). The phantom is fabricated
+  client-side after the merge — it never existed in the right database.
+
+- **One pair per resolved right row.** A left row whose relation resolves to *N* existing
+  right pages emits *N* rows (inner or outer); the outer-join phantom appears only when
+  *N = 0*.
+
+## Alternatives Considered
+
+**A. Raise on a dangling reference.**
+Rejected. It contradicts ADR-0002's lax-FK contract and real Notion (which accepts any
+UUID-shaped string at write time), and would make test/prod behaviour diverge on
+out-of-order inserts.
+
+**B. Outer join fabricates a typed empty right row instead of None-fill.**
+Rejected here and in [ADR-0005](./0005-outer-join-phantom-null-semantics.md): None-fill +
+SQL NULL semantics is type-independent, whereas per-type Notion-empty values invent shapes
+Notion never has and answer the wrong question.
+
+## Consequences
+
+- The inner-join drop is **invisible** unless a test asserts on join cardinality — dangling
+  references do not announce themselves. Tests that care must assert row counts explicitly
+  (ADR-0002 already flagged this).
+- **SQL anti-join is inexpressible.** The classic `LEFT JOIN … WHERE right IS NULL` cannot
+  be written: Notion has no `IS NULL`, `is_empty` ≠ `IS NULL`, and any right-side `WHERE`
+  drops the phantom (ADR-0005). Only a bare `outerjoin()` (no right-side predicate) preserves
+  unmatched left rows. This is a deliberate v1 boundary, not a bug.
+- **Multi-join chaining is not yet supported.** Join execution consumes only the first join
+  (`_joins[0]`); chaining `.join()/.outerjoin()` silently drops the rest. Out of scope for
+  v1 — a multi-join slice (with a loud guard or a real fan-out) is needed before chaining is
+  safe.
+- **Self-referential joins are untested.** FK auto-detect (slice 4 / #306) does not forbid a
+  table joining itself, but that path is unexercised and out of scope until a dedicated
+  slice covers it.

--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -195,14 +195,14 @@ class Connection:
         """
         
         # delegate to statement execution trigger
-        try:
-            exec_method = stmt._execute_on_connection(
-                self, 
-                parameters, 
-                execution_options=execution_options
-            )
-        except AttributeError as ae:
-            raise ObjectNotExecutableError(stmt) from ae 
+        if not stmt.supports_execution:
+            raise ObjectNotExecutableError(stmt)
+    
+        exec_method = stmt._execute_on_connection(
+            self, 
+            parameters, 
+            execution_options=execution_options
+        )
         
         return exec_method
     
@@ -264,14 +264,11 @@ class Connection:
         elem = context.invoked_stmt
         
         # 6. side effects happen (HTTP)
-        try:
-            self._engine.do_execute(
-                context._get_exec_cursor(), 
-                context.operation, 
-                context.parameters
-            )
-        except Error as exc:
-            elem._handle_dbapi_error(exc, context)
+        self._engine.do_execute(
+            context._get_exec_cursor(), 
+            context.operation, 
+            context.parameters
+        )
 
     
     def _execute_many(self, context: ExecutionContext) -> None:
@@ -280,28 +277,22 @@ class Connection:
         # 6. side effects happen (HTTP)
         #    execute_many uses the bulk_* attributes which have been prepared in the 
         #    invoked statement's _finilize_execution() hook
-        try:
-            self._engine.do_executemany(
-                context._get_exec_cursor(), 
-                context.bulk_operation, 
-                context.bulk_parameters
-            )
-        except Error as exc:
-            elem._handle_dbapi_error(exc, context)
+        self._engine.do_executemany(
+            context._get_exec_cursor(), 
+            context.bulk_operation, 
+            context.bulk_parameters
+        )
 
     def _execute_insert_many(self, context: ExecutionContext) -> None:
         elem = context.invoked_stmt
 
         # 6. side effects happen (HTTP)
         #    insert_many expects a multi-payload in parameters
-        try:
-            self._engine.do_executemany(
-                context._get_exec_cursor(), 
-                context.operation, 
-                context.parameters
-            )
-        except Error as exc:
-            elem._handle_dbapi_error(exc, context)
+        self._engine.do_executemany(
+            context._get_exec_cursor(), 
+            context.operation, 
+            context.parameters
+        )
 
     def _resolve_execution_options(self, stmt_execution_options: ExecutionOptions) -> ExecutionOptions:
         """Resolve the connection's execution options with the statement's ones."""

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from normlite.notiondbapi.dbapi2 import Cursor as DBAPICursor
     from normlite.sql.base import Executable
     from normlite.sql.elements import BindParameter
+    from normlite.sql.dml import Join
 
 class ExecutionStyle(Enum):
     """Define the execution style for a context.
@@ -297,6 +298,18 @@ class ExecutionContext:
     .. versionadded:: 0.9.0
     """
 
+    _join: Optional[Join] = None
+    """Gives onclause + left/right tables"""
+
+    _join_left_rows: Optional[list[tuple]] = None
+    """drained left pages"""
+
+    _join_left_schema: Optional[SchemaInfo] = None
+    """to resolve FK column index"""
+
+    _join_right_schema: Optional[SchemaInfo] = None
+    """to read object_id from the right rows"""
+
     def __init__(
             self,
             engine: Engine,
@@ -385,6 +398,11 @@ class ExecutionContext:
 
         # delete or update with single parameters
         if stmt.is_delete or stmt.is_update:
+            return ExecutionStyle.EXECUTEMANY
+        
+        # NEW: Select with joins is two-phase — phase-1 databases.query,
+        # phase-2 bulk pages.retrieve (Select.join, slice 2 of #302)
+        if stmt.is_select and stmt._joins:
             return ExecutionStyle.EXECUTEMANY
         
         # select or insert without returning

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -244,6 +244,12 @@ class ExecutionContext:
     .. versionadded:: 0.8.0
     """
 
+    join_right_filter: Optional[dict]
+    """The optional filter expression for WHERE clauses with right columns expressions
+    
+    .. versionadded:: 0.11.0
+    """
+
     execution_style: ExecutionStyle
     """The style of DBAPI cursor method that will be used to execute a statement.
 
@@ -331,6 +337,7 @@ class ExecutionContext:
         self.path_params = None
         self.query_params = None
         self.payload = None
+        self.join_right_filter = None
         self._result = None
         self._rowcount = None
         self._returned_primary_keys_rows = None
@@ -511,6 +518,10 @@ class ExecutionContext:
                 ]
             else:
                 self.payload = self._bind_params(template, resolved_params[0])
+
+        if 'join_right_filter' in self.compiled_dict:
+            template = self.compiled_dict['join_right_filter']
+            self.join_right_filter = self._bind_params(template, resolved_params[0])
 
         if self.invoked_stmt.is_update:
             self.resolved_params = dict(resolved_params[0])

--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -45,9 +45,7 @@ The design of SQL statement execution separates responsibilities cleanly using t
 """
 from __future__ import annotations
 from enum import Enum, auto
-import pdb
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Union, Sequence
-import copy
 
 from normlite.exceptions import ArgumentError, StatementError
 from normlite.engine.interfaces import _CoreMultiExecuteParams, ExecutionOptions

--- a/src/normlite/notion_sdk/client.py
+++ b/src/normlite/notion_sdk/client.py
@@ -1004,7 +1004,9 @@ class InMemoryNotionClient(AbstractNotionClient):
         if not obj:
             raise NotionError(
                 f"Could not find page with ID: {page_id}. "
-                "Make sure the relevant pages and databases are shared with your integration."
+                "Make sure the relevant pages and databases are shared with your integration.",
+                status_code=404,
+                code="object_not_found"
             )
         return copy.deepcopy(obj)
 

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 from operator import itemgetter
-from typing import Any, Dict, Iterator, List, Literal, NoReturn, Optional, Self, Sequence, Tuple, TypeAlias, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, NoReturn, Optional, Self, Sequence, Tuple, Type, TypeAlias, Union
 from itertools import islice
 import uuid
 from flask.testing import FlaskClient
@@ -39,6 +39,28 @@ DBAPIParamStyle = Literal[
 
 DBAPIExecuteParameters: TypeAlias = dict     # in future, Union[dict, Sequence[dict]] for multi execute params
 """Type for parameters passed to for SQL statement execution."""
+
+type DBAPIErrorHandlerType = Callable[[Connection, Cursor, Type[BaseException], BaseException], None]
+"""Type alias for PEP 249 ``errorhandler`` to call in case of error conditions.
+
+    .. versionadded:: 0.11.0
+ """
+
+def _default_errorhandler(
+    connection: Connection, 
+    cursor: Cursor, 
+    errorclass: Type[BaseException],
+    errorvalue: BaseException
+) -> None:
+                          
+    """Default PEP 249 error handler.
+    
+    The default error handler simply raises the ``errorvalue``.
+
+    .. versionadded:: 0.11.0
+    """
+    raise errorvalue
+
 
 class Error(Exception):
     """Base class of all other error exceptions.
@@ -121,8 +143,27 @@ class Cursor:
     .. versionadded:: 0.7.0
 
     """
-    def __init__(self, client: AbstractNotionClient):
-        self._client = client
+
+    _errorhandler: DBAPIErrorHandlerType
+    """Read/write attribute which references an error handler to call in case an error condition is met.
+    
+    .. versionadded:: 0.11.0
+    """
+    
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+        """The DBAPI connection this cursor refers to.
+
+        .. versionadded::0.11.0
+        """
+
+        self._errorhandler: Optional[DBAPIErrorHandlerType] = None
+        """Per-cursor error handler; falls back to the connection's when unset.
+
+        .. versionadded:: 0.11.0
+        """
+
+        self._client = connection._client
         """The client implementing the Notion API."""
 
         self._result_sets: list[ResultSet] = []
@@ -173,6 +214,14 @@ class Cursor:
         
         .. versionadded:: 0.9.0
         """
+
+    @property
+    def errorhandler(self) -> DBAPIErrorHandlerType:
+        return self._errorhandler or self._connection.errorhandler
+    
+    @errorhandler.setter
+    def errorhandler(self, fn: DBAPIErrorHandlerType) -> None:
+        self._errorhandler = fn
 
     @property
     def _current_result_set(self) -> Optional[ResultSet]:
@@ -685,39 +734,51 @@ class Cursor:
                 ) from ke
 
             except NotionError as ne:
-                # --- Database object does not exist -----------------------------
-                if ne.code == "object_not_found":
-                    raise ProgrammingError(
-                        f'NotionError("Object not found: {ne}'
-                    ) from ne
+                errorclass, errorvalue = self._translate_notion_error(ne)
+                self.errorhandler(self._connection, self, errorclass, errorvalue)
+                continue            # IMPORTANT: error is handled, do not abort the loop
 
-                # --- Authentication / authorization -----------------------------
-                if ne.code in {"unauthorized", "forbidden"}:
-                    raise OperationalError(
-                        f'Authentication/authorization failure: {ne}'
-                    ) from ne
-
-                # --- Rate limiting / availability -------------------------------
-                if ne.code in {"rate_limited", "service_unavailable"}:
-                    raise OperationalError(
-                        f'Backend temporarily unavailable: {ne}'
-                    ) from ne
-
-                # --- Malformed request / client misuse --------------------------
-                if ne.code in {"invalid_request", "validation_error"}:
-                    raise InterfaceError(
-                        f'Invalid request sent to backend: {ne}'
-                    ) from ne
-
-                # --- Fallback: backend rejected operation -----------------------
-                raise DatabaseError(
-                    f'Unhandled NotionError("{self._client.__class__.__name__}"): {ne}'
-                ) from ne
-            
             self._append_result_set(object_)
         
         return self
-        
+    
+    def _translate_notion_error(self, ne: NotionError) -> tuple[Type[Error], Error]:
+        """Map a NotionError to a DBAPI 2.0 (errorclass, errorvalue) pair.
+
+        Centralises the wrapping logic previously duplicated across
+        .execute() and .executemany(). Returns the pair rather than
+        raising so the caller can route through .errorhandler.
+
+        The returned errorvalue has ``__cause__`` set to the original
+        NotionError, matching what ``raise X(...) from ne`` would produce.
+        """
+        # --- Database object does not exist -----------------------------
+        if ne.code == "object_not_found":
+            exc = ProgrammingError(f'NotionError("Object not found: {ne}') 
+
+        # --- Authentication / authorization -----------------------------
+        elif ne.code in {"unauthorized", "forbidden"}:
+            exc = OperationalError(f'Authentication/authorization failure: {ne}')
+
+        # --- Rate limiting / availability -------------------------------
+        elif ne.code in {"rate_limited", "service_unavailable"}:
+            exc = OperationalError(f'Backend temporarily unavailable: {ne}')
+
+        # --- Malformed request / client misuse --------------------------
+        elif ne.code in {"invalid_request", "validation_error"}:
+            exc = InterfaceError(f'Invalid request sent to backend: {ne}')
+
+        else:
+        # --- Fallback: backend rejected operation -----------------------
+            exc = DatabaseError(
+                f'Unhandled NotionError("{self._client.__class__.__name__}"): {ne}'
+            )
+
+        # Mirror `raise X(...) from ne` semantics manually
+        exc.__cause__ = ne
+        exc.__suppress_context__ = True
+        return type(exc), exc
+            
     def nextset(self) -> bool:
         """Advance to the next available result set.
         
@@ -781,6 +842,12 @@ class Connection:
 
     """
 
+    errorhandler: DBAPIErrorHandlerType
+    """Read/write attribute which references an error handler to call in case an error condition is met.
+
+    .. versionadded:: 0.11.0
+    """
+
     def __init__(self, client: AbstractNotionClient, isolation_level: Optional[IsolationLevel] = 'AUTOCOMMIT'):
         self._isolation_level = isolation_level
         """The isolation level set for this database connection."""
@@ -790,6 +857,8 @@ class Connection:
 
         self._cursor: Cursor = None
         """Classic DBAPI cursor to execute operations and fetch rows."""
+
+        self.errorhandler = _default_errorhandler
 
     @property
     def autocommit(self) -> bool:
@@ -818,9 +887,8 @@ class Connection:
         """
  
         # IMPORTANT: The DBAPI connection must always procure a new cursor because this has a per-operation lifecyle
-        return Cursor(self._client)
-    
-    
+        return Cursor(self)
+        
     def _begin_transaction(self) -> None:
         """Begin a new transaction."""
 

--- a/src/normlite/sql/base.py
+++ b/src/normlite/sql/base.py
@@ -169,9 +169,16 @@ class Executable(ClauseElement):
     """
 
     is_insert: ClassVar[bool] = False
+    """``True`` if executable is an INSERT statement."""
 
     is_update: ClassVar[bool] = False
     """``True`` if executable is an UPDATE statement."""
+
+    is_select: ClassVar[bool] = False
+    """``True`` if executable is a SELECT statement.
+    
+    .. versionadded:: 0.11.0
+    """
 
     _execution_options: Optional[ExecutionOptions] = None
     """per-statement execution options.
@@ -284,9 +291,9 @@ class Executable(ClauseElement):
             context (ExecutionContext): The execution context in which this executables is running.
 
         Returns:
-            Optional[NoReturn]: Nothin
+            Optional[NoReturn]: Nothing
         """
-        raise NotImplementedError
+        raise exc
 
 class _CompileState(Enum):
     """Helper class used internally during compilation.

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -17,8 +17,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 from contextlib import contextmanager
-import pdb
-from typing import TYPE_CHECKING, Any, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Optional, Set
 
 from normlite._constants import SpecialColumns
 from normlite.exceptions import CompileError, StatementError

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -33,7 +33,7 @@ from normlite.sql.schema import Column, ReadOnlyColumnCollection
 
 if TYPE_CHECKING:
     from normlite.sql.ddl import CreateTable, DropTable, ReflectTable
-    from normlite.sql.dml import Insert, Select
+    from normlite.sql.dml import Insert, Select, Join
     from normlite.sql.elements import UnaryExpression, BinaryExpression, BindParameter
 
 class NotionCompiler(SQLCompiler):
@@ -519,6 +519,14 @@ class NotionCompiler(SQLCompiler):
             'direction': expr.direction
         }
 
+    def visit_join(self, join: Join) -> dict:
+        return {
+            "left": join.left.name,
+            "right": join.right.name,
+            "onclause": join.onclause.name,
+            "isouter": join.isouter
+        }
+
     def visit_select(self, select: Select) -> dict:
         self._compiler_state.is_select = select.is_select
         self._compiler_state.stmt = select
@@ -588,6 +596,12 @@ class NotionCompiler(SQLCompiler):
             'path_params': path_params, 
             'payload': payload
         }
+
+        # add a new top-level 'joins' key to store the joins, if any
+        joins = [j.compile(self).as_dict() for j in select._joins]
+        if joins:
+            # emit only when non-empty
+            compiled_dict["joins"] = joins
 
         if query_params:           
             compiled_dict['query_params'] = query_params

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -18,13 +18,13 @@
 from __future__ import annotations
 from contextlib import contextmanager
 import pdb
-from typing import TYPE_CHECKING, Any, Optional, Set
+from typing import TYPE_CHECKING, Any, Optional, Set, Union
 
 from normlite._constants import SpecialColumns
 from normlite.exceptions import CompileError, StatementError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
 from normlite.sql._sentinels import VALUE_PLACEHOLDER
-from normlite.sql.base import _CompileState, SQLCompiler
+from normlite.sql.base import _CompileState, ClauseElement, SQLCompiler
 from normlite.sql.dml import Delete, Update, OrderByClause
 from normlite.sql.elements import _BindRole, Operator, OrderByExpression, ColumnElement, BinaryExpression
 from normlite.sql.elements import _NoArg
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from normlite.sql.elements import UnaryExpression, BindParameter
     from normlite.sql.schema import Table
 
-def _get_expression_parent_tables(expression: ColumnElement) -> Set[Table]:
+def _get_expression_parent_tables(expression: ClauseElement) -> Set[Table]:
     """Helper to recursively collect all parent tables corresponding to 
     the columns involved in the expression.
     
@@ -62,6 +62,13 @@ def _get_expression_parent_tables(expression: ColumnElement) -> Set[Table]:
     elif isinstance(expression, BooleanClauseList):
         for clause in expression.clauses:
             parents |= _get_expression_parent_tables(clause)
+    
+    elif isinstance(expression, OrderByClause):
+        for clause in expression.clauses:
+            parents |= _get_expression_parent_tables(clause)
+
+    elif isinstance(expression, OrderByExpression):
+        parents |= _get_expression_parent_tables(expression.column)
     
     return parents
 
@@ -597,7 +604,7 @@ class NotionCompiler(SQLCompiler):
      
         if select._whereclause.has_expression():
             expression = select._whereclause.expression
-            parent_tables = list(_get_expression_parent_tables(expression))
+            parent_tables = _get_expression_parent_tables(expression)
             if not parent_tables:
                 # A WHERE expression is present but the router could attribute it
                 # to no source table. This is not a routing outcome but a failure
@@ -608,7 +615,7 @@ class NotionCompiler(SQLCompiler):
                     f"Cannot route WHERE expression: no source table could be "
                     f"determined for {type(expression).__name__}."
                 )
-            if len(parent_tables) == 1 and parent_tables[0] is select._table:
+            if parent_tables == {select._table}:
                 with self._compiling(new_state=_CompileState.COMPILING_WHERE):
                     # emit the JSON code for the filter object of the query
                     # in the right context
@@ -642,8 +649,22 @@ class NotionCompiler(SQLCompiler):
                 query_params['filter_properties'] = self._compiler_state.result_columns
 
         if select._order_by.has_expression():
-            sorts_obj = select._order_by._compiler_dispatch(self)
-            payload['sorts'] = sorts_obj
+            order_by_clause = select._order_by
+            parent_tables = _get_expression_parent_tables(order_by_clause)
+            if not parent_tables:
+                # An ORDER BY expression is present but the router could attribute it
+                # to no source table. This is not a routing outcome but a failure
+                # to route — most likely an unsupported expression node type.
+                # Fail loudly at compile time rather than silently dropping the
+                # sort (which would return rows in the wrong order with no error).
+                raise CompileError(
+                    f"Cannot route ORDER BY expression: no source table could be "
+                    f"determined for {type(order_by_clause).__name__}."
+                )
+ 
+            if parent_tables == {select._table}:
+                sorts_obj = select._order_by._compiler_dispatch(self)
+                payload['sorts'] = sorts_obj
 
         compiled_dict ["payload"] = payload
         

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -17,9 +17,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 from contextlib import contextmanager
-import copy
 import pdb
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Set
 
 from normlite._constants import SpecialColumns
 from normlite.exceptions import CompileError, StatementError
@@ -27,14 +26,44 @@ from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
 from normlite.sql._sentinels import VALUE_PLACEHOLDER
 from normlite.sql.base import _CompileState, SQLCompiler
 from normlite.sql.dml import Delete, Update, OrderByClause
-from normlite.sql.elements import _BindRole, _NoArg, BooleanClauseList, Operator, OrderByExpression, ColumnElement
+from normlite.sql.elements import _BindRole, Operator, OrderByExpression, ColumnElement, BinaryExpression
+from normlite.sql.elements import _NoArg
+from normlite.sql.elements import BooleanClauseList, UnaryExpression   
 from normlite.sql.elements import BindParameter
-from normlite.sql.schema import Column, ReadOnlyColumnCollection
+from normlite.sql.schema import ReadOnlyColumnCollection, Column
 
 if TYPE_CHECKING:
     from normlite.sql.ddl import CreateTable, DropTable, ReflectTable
     from normlite.sql.dml import Insert, Select, Join
-    from normlite.sql.elements import UnaryExpression, BinaryExpression, BindParameter
+    from normlite.sql.elements import UnaryExpression, BindParameter
+    from normlite.sql.schema import Table
+
+def _get_expression_parent_tables(expression: ColumnElement) -> Set[Table]:
+    """Helper to recursively collect all parent tables corresponding to 
+    the columns involved in the expression.
+    
+    .. note::
+        Unrecognized nodes contribute no tables; the top-level guard in visit_select catches 
+        only a fully-unattributable expression. 
+        A new WHERE node type must extend this fold or it routes silently.
+    """
+
+    parents = set()
+
+    if isinstance(expression, Column):
+        parents.add(expression.parent)
+    
+    elif isinstance(expression, BinaryExpression):
+        parents |= _get_expression_parent_tables(expression.column)
+    
+    elif isinstance(expression, UnaryExpression):
+        parents |= _get_expression_parent_tables(expression.element)
+
+    elif isinstance(expression, BooleanClauseList):
+        for clause in expression.clauses:
+            parents |= _get_expression_parent_tables(clause)
+    
+    return parents
 
 class NotionCompiler(SQLCompiler):
     """Notion compiler for SQL statements.
@@ -533,13 +562,23 @@ class NotionCompiler(SQLCompiler):
         self._compiler_state.result_columns = []
 
         operation = dict(endpoint='databases', request='query')
+        compiled_dict = {
+            'operation': operation, 
+        }
+
         path_params = {}
         query_params = {}
         payload = {
             'page_size': 100,        # Notion imposed max page size
             'in_trash': False,       # Always return non deleted pages only
         }
-        
+
+        # add a new top-level 'joins' key to store the joins, if any
+        joins = [j._compiler_dispatch(self) for j in select._joins]
+        if joins:
+            # emit only when non-empty
+            compiled_dict["joins"] = joins
+
         table = select.get_table()
         database_id = table.get_oid()
         if database_id is None:
@@ -553,13 +592,28 @@ class NotionCompiler(SQLCompiler):
                 )
             )
             path_params['database_id'] = f':{db_id_key}'
+            compiled_dict["path_params"] = path_params 
+
      
         if select._whereclause.has_expression():
-            with self._compiling(new_state=_CompileState.COMPILING_WHERE):
-                # emit the JSON code for the filter object of the query
-                # in the right context
-                filter_obj = select._whereclause.expression._compiler_dispatch(self)
-                payload['filter'] = filter_obj
+            expression = select._whereclause.expression
+            parent_tables = list(_get_expression_parent_tables(expression))
+            if not parent_tables:
+                # A WHERE expression is present but the router could attribute it
+                # to no source table. This is not a routing outcome but a failure
+                # to route — most likely an unsupported expression node type.
+                # Fail loudly at compile time rather than silently dropping the
+                # filter (which would return wrong rows with no error).
+                raise CompileError(
+                    f"Cannot route WHERE expression: no source table could be "
+                    f"determined for {type(expression).__name__}."
+                )
+            if len(parent_tables) == 1 and parent_tables[0] is select._table:
+                with self._compiling(new_state=_CompileState.COMPILING_WHERE):
+                    # emit the JSON code for the filter object of the query
+                    # in the right context
+                    filter_obj = select._whereclause.expression._compiler_dispatch(self)
+                    payload['filter'] = filter_obj
 
         projection = self._compiler_state.stmt._projection
 
@@ -591,18 +645,8 @@ class NotionCompiler(SQLCompiler):
             sorts_obj = select._order_by._compiler_dispatch(self)
             payload['sorts'] = sorts_obj
 
-        compiled_dict = {
-            'operation': operation, 
-            'path_params': path_params, 
-            'payload': payload
-        }
-
-        # add a new top-level 'joins' key to store the joins, if any
-        joins = [j._compiler_dispatch(self) for j in select._joins]
-        if joins:
-            # emit only when non-empty
-            compiled_dict["joins"] = joins
-
+        compiled_dict ["payload"] = payload
+        
         if query_params:           
             compiled_dict['query_params'] = query_params
 

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -633,7 +633,15 @@ class NotionCompiler(SQLCompiler):
             self._compiler_state.fetch_columns = [
                 col.name
                 for col in projection
+                if col.name in select._table.c  # join path supplies only its left-owned projection
             ]
+
+            if select._joins:
+                # add the onclause column name to the set of columns to be fetched
+                # this ensures it is encoded in the filter properties
+                self._compiler_state.fetch_columns.append(
+                    compiled_dict["joins"][0]["onclause"]
+                )
 
             self._compiler_state.result_columns = [
                 col 

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -598,7 +598,7 @@ class NotionCompiler(SQLCompiler):
         }
 
         # add a new top-level 'joins' key to store the joins, if any
-        joins = [j.compile(self).as_dict() for j in select._joins]
+        joins = [j._compiler_dispatch(self) for j in select._joins]
         if joins:
             # emit only when non-empty
             compiled_dict["joins"] = joins

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -615,12 +615,17 @@ class NotionCompiler(SQLCompiler):
                     f"Cannot route WHERE expression: no source table could be "
                     f"determined for {type(expression).__name__}."
                 )
-            if parent_tables == {select._table}:
+            if parent_tables <= {select._table, select._right}:
                 with self._compiling(new_state=_CompileState.COMPILING_WHERE):
                     # emit the JSON code for the filter object of the query
                     # in the right context
                     filter_obj = select._whereclause.expression._compiler_dispatch(self)
-                    payload['filter'] = filter_obj
+                    if parent_tables == {select._table}:
+                        # for the left table, add "filter" to the payload for the databases.query
+                        payload['filter'] = filter_obj
+                    else:
+                        # for the right table, stash the filter for filtering after merging
+                        compiled_dict["join_right_filter"] = filter_obj
 
         projection = self._compiler_state.stmt._projection
 

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -240,26 +240,26 @@ def _project_join_row(
 def _merge_rows_with_right_side_filter(
     context: ExecutionContext,
     merged_rows: Sequence[tuple],
-    *, 
-    projection: Optional[ReadOnlyColumnCollection]
+    *,
+    merged_schema: Optional[SchemaInfo], 
 ) -> Sequence[tuple]:
-    right_schema = context._join_right_schema
-    # full right user columns, in merged-row right-part order
-    right_cols = [c for c in right_schema.columns if c.name != "object_id"]
-    left_width = len([c for c in context._join_left_schema.columns if c.name != "object_id"])
-
     join_right_filter = context.join_right_filter
     if join_right_filter is not None:
+        # build the getters from the merged_schema
+        right = context._join.right
+        right_cols = [c for c in merged_schema.columns if c.name in right.uc]
+        right_getters = [merged_schema.column_getter(c.name) for c in right_cols]
         merged_rows = [
             r for r in merged_rows
-            if _right_side_passes(r, join_right_filter, left_width, right_cols)
+            if _right_side_passes(r, join_right_filter, right_getters, right_cols)
         ]
+
     return merged_rows
 
 def _right_side_passes(
     merged_row: tuple[Any, ...],
     right_filter: str,
-    left_width: int, 
+    row_getters: list[Callable[[Sequence[Any]], Any]], 
     right_cols: Sequence[ResultColumn]
 ) -> bool:
     """Shape adapter to apply ``_Filter`` predicate coming from WHERE clause on right columns."""
@@ -278,7 +278,11 @@ def _right_side_passes(
         DBAPITypeCode.RELATION: "relation"
     }
 
-    right_slice = merged_row[left_width:]
+    right_slice = tuple([
+        getter(merged_row)
+        for getter in row_getters
+    ])
+
     if all(c is None for c in right_slice):
         return False        # phantom: NULL fails every right-side predicate
 
@@ -1067,7 +1071,7 @@ class Select(HasTable, ExecutableClauseElement):
         filtered_rows = _merge_rows_with_right_side_filter(
             context,
             merged_rows,
-            projection=self._projection
+            merged_schema=joined,
         )
 
         # fill in the result cursor's result set    

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -23,11 +23,11 @@ from normlite.notiondbapi.resultset import ResultSet
 from normlite.sql.schema import ColumnCollection
 
 from types import MappingProxyType
-from typing import Any, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING
+from typing import Any, Callable, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING
 import collections.abc as collections_abc
 
 import warnings
-from normlite.exceptions import ArgumentError
+from normlite.exceptions import ArgumentError, NoSuchColumnError
 from normlite.sql.base import Executable, ClauseElement, generative
 from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList, ColumnElement
 from normlite.sql.resultschema import ResultColumn, SchemaInfo
@@ -86,7 +86,8 @@ def merge_inner_join_rows(
     onclause_column: Column,
     left_rows: list[tuple],
     right_rows: list[tuple],
-    isouter: bool = False
+    isouter: bool = False,
+    projection: Optional[ReadOnlyColumnCollection] = None,
 ) -> list[tuple]:
     """Cross-product left rows with right rows whose object_id matches the
     decoded relation list on each left row.
@@ -138,7 +139,9 @@ def merge_inner_join_rows(
                     left_schema,
                     right_schema,
                     left_row,
-                    right_row
+                    right_row,
+                    projection=projection,
+                    left_table=onclause_column.parent
                 )
             )
 
@@ -154,7 +157,9 @@ def merge_inner_join_rows(
                     left_schema,
                     right_schema,
                     left_row,
-                    None
+                    None,
+                    projection=projection,
+                    left_table=onclause_column.parent
                 )
             )
 
@@ -163,40 +168,99 @@ def merge_inner_join_rows(
 def _project_join_row(
     left_schema: SchemaInfo,
     right_schema: SchemaInfo,
-    left_row: tuple, 
-    right_row: tuple
+    left_row: tuple,
+    right_row: Optional[tuple],
+    projection: Optional[ReadOnlyColumnCollection] = None,
+    left_table: Optional[Table] = None,
 ) -> tuple:
-    left_projected = tuple(
-        [
-            left_row[left_schema.column_index(lc.name)] 
-            for lc in left_schema.columns 
-            if lc.name != "object_id"
-        ]
-    )
+    """Construct the row resulting from the join merging the left and the right row.
+
+    Args:
+        left_schema (SchemaInfo): Schema for the left row
+        right_schema (SchemaInfo): Schema for the right row
+        left_row (tuple): Left row as a tuple of values
+        right_row (Optional[tuple]): right row as a tuple of values.
+        It can be None (no matching row in outer join).
+        projection (Optional[ReadOnlyColumnCollection], optional): A collection of columns to be projected. Defaults to None.
+        left_table (Optional[Table], optional): The left table of the join. Used to decide,
+        for each projected column, whether it is owned by the left or the right side. Required
+        whenever ``projection`` is given. Defaults to None.
+
+    Returns:
+        tuple: The resulting row as a tuple of values.
+    """
+
+    if projection is not None:
+        # Project in PROJECTION ORDER, exactly one value per projected column,
+        # sourced from the column's OWNING table. Ownership is decided by
+        # identity (col.parent is left_table), NOT by name membership in a
+        # schema: under a name collision both schemas contain the name, so name
+        # membership is ambiguous -- it would emit the wrong side's value and
+        # double-count the column.
+        projected = tuple()
+        for col in projection:
+            if col.parent is left_table:
+                # left-owned column: take its value from the left row
+                getter = left_schema.column_getter(col.name)
+                projected += (getter(left_row),)
+            elif right_row is not None:
+                # right-owned column with a matching right row
+                getter = right_schema.column_getter(col.name)
+                projected += (getter(right_row),)
+            else:
+                # right-owned column with no right row (outer-join phantom)
+                projected += (None,)
+
+        return projected
+
+    # No projection given: project ALL user columns from both sides
+    # (left then right), skipping object_id. Right side is None-filled when
+    # there is no matching right row.
+    left_projected = tuple([
+        left_row[left_schema.column_index(lc.name)]
+        for lc in left_schema.columns
+        if lc.name != "object_id"
+    ])
+
     if right_row is not None:
-        right_projected = tuple(
-            [
-                right_row[right_schema.column_index(rc.name)] 
-                for rc in right_schema.columns 
-                if rc.name != "object_id"
-            ]
-        )
+        right_projected = tuple([
+            right_row[right_schema.column_index(rc.name)]
+            for rc in right_schema.columns
+            if rc.name != "object_id"
+        ])
     else:
-        right_projected = tuple(
-            [
-                None 
-                for rc in right_schema.columns 
-                if rc.name != "object_id"
-            ]
-        )
+        right_projected = tuple([
+            None
+            for rc in right_schema.columns
+            if rc.name != "object_id"
+        ])
 
     return (*left_projected, *right_projected)
 
+def _merge_rows_with_right_side_filter(
+    context: ExecutionContext,
+    merged_rows: Sequence[tuple],
+    *, 
+    projection: Optional[ReadOnlyColumnCollection]
+) -> Sequence[tuple]:
+    right_schema = context._join_right_schema
+    # full right user columns, in merged-row right-part order
+    right_cols = [c for c in right_schema.columns if c.name != "object_id"]
+    left_width = len([c for c in context._join_left_schema.columns if c.name != "object_id"])
+
+    join_right_filter = context.join_right_filter
+    if join_right_filter is not None:
+        merged_rows = [
+            r for r in merged_rows
+            if _right_side_passes(r, join_right_filter, left_width, right_cols)
+        ]
+    return merged_rows
+
 def _right_side_passes(
-    merged_row, 
-    right_filter, 
-    left_width, 
-    right_cols: list[ResultColumn]
+    merged_row: tuple[Any, ...],
+    right_filter: str,
+    left_width: int, 
+    right_cols: Sequence[ResultColumn]
 ) -> bool:
     """Shape adapter to apply ``_Filter`` predicate coming from WHERE clause on right columns."""
 
@@ -779,7 +843,7 @@ class Select(HasTable, ExecutableClauseElement):
                 # select columns from multiple tables: join case
                 self._table = entities[0]
                 self._right = entities[1]
-                self._projection = ColumnCollection().as_readonly()
+                self._projection = [*self._table.uc, *self._right.uc]
                 return 
 
         # A list of columns has been provided
@@ -995,31 +1059,23 @@ class Select(HasTable, ExecutableClauseElement):
             context._join.onclause, 
             context._join_left_rows, 
             right_rows,
-            isouter=context._join.isouter
+            isouter=context._join.isouter,
+            projection=self._projection
         )
 
         # filter the right rows if WHERE clause contains a condition on right columns
-        join_right_filter = context.join_right_filter
-        left_width = len([c for c in context._join_left_schema.columns if c.name != "object_id"])
-        right_cols = [c for c in context._join_right_schema.columns if c.name != "object_id"]
-        if join_right_filter is not None:
-            merged_rows = [
-                r
-                for r in merged_rows
-                if _right_side_passes(
-                    r,
-                    join_right_filter,
-                    left_width,
-                    right_cols
-                )
-            ]
+        filtered_rows = _merge_rows_with_right_side_filter(
+            context,
+            merged_rows,
+            projection=self._projection
+        )
 
         # fill in the result cursor's result set    
         context._result_cursor._result_sets.append(
             ResultSet(
                 joined.as_sequence(),
                 "page",
-                merged_rows
+                filtered_rows
             )
         )
 
@@ -1028,11 +1084,10 @@ class Select(HasTable, ExecutableClauseElement):
         # the joined table has all left and right table's columns 
         left = context._join.left
         right = context._join.right
-        return SchemaInfo.from_join(left, right)
+        return SchemaInfo.from_join(left, right, *self._projection)
     
 def select(*entities: Union[Table, Column]) -> Select:
     return Select(*entities)
-        
 
 class Delete(UpdateBase):
     """Represent a SQL DELETE statement."""

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -783,7 +783,7 @@ class Select(HasTable, ExecutableClauseElement):
                 return 
 
         # A list of columns has been provided
-        tables = set()
+        tables = []
         columns: list[tuple[str, Column]] = []
 
         for ent in entities:
@@ -791,24 +791,37 @@ class Select(HasTable, ExecutableClauseElement):
                 raise ArgumentError(
                     "select() arguments must be either a Table or Column objects"
                 )
-            tables.add(ent.parent)
+            tables.append(ent.parent)
             columns.append((ent.name, ent))
 
-        if len(tables) != 1:
+        dedup_tables = list(dict.fromkeys(tables))
+
+        if len(dedup_tables) > 2:
             raise ArgumentError(
-                "All selected columns must belong to the same table"
+                f"All selected columns must either belong to the same table or "
+                f"belong to max. 2 tables (left and right tables for JOIN clause). "
+                f"You supplied columns from {len(dedup_tables)} tables."
             )
 
-        self._table: Table = tables.pop()
-        # --- SAFEGUARD: column names must exist on the table ---
+        self._table: Table = dedup_tables[0]
+        self._right = dedup_tables[1] if len(dedup_tables) == 2 else None
+        # --- SAFEGUARD: column names must exist on each table ---
         table_columns: ReadOnlyColumnCollection = self._table.columns
 
         for column in columns:
             _, col = column
-            if col.name not in table_columns:
+            if (
+                col.name not in table_columns 
+                and 
+                self._right is not None
+                and
+                col.name not in self._right.columns
+            ):
                 raise ArgumentError(
-                    f'Column: {col.name} does not belong to table: {self._table.name}'
+                    f"Column: {col.name} must either belong to '{self._table.name}' or "
+                    f"to {self._right.name}"
                 )
+
         self._projection = ColumnCollection(columns).as_readonly()
 
     @generative
@@ -914,7 +927,7 @@ class Select(HasTable, ExecutableClauseElement):
         context._join = self._joins[0]
         context._join_left_schema = SchemaInfo.from_table(
             context._join.left,
-            execution_names=context.compiled.fetch_columns(),
+            execution_names=[context._join.left.c.object_id.name],
             projected_names=[c.name for c in context._join.left.uc]  
         )
         context._cursor._inject_description(
@@ -935,7 +948,7 @@ class Select(HasTable, ExecutableClauseElement):
         result_cursor = context.connection._engine.raw_connection().cursor()
         right_schema: SchemaInfo = SchemaInfo.from_table(
             context._join.right,
-            execution_names=context.compiled.fetch_columns(),
+            execution_names=[context._join.right.c.object_id.name],
             projected_names=[c.name for c in context._join.right.uc]    
         )
         result_cursor._inject_description(right_schema.as_sequence())
@@ -1015,16 +1028,7 @@ class Select(HasTable, ExecutableClauseElement):
         # the joined table has all left and right table's columns 
         left = context._join.left
         right = context._join.right
-        joined_table_cols = [*left.uc, *right.uc]
-        result_cols = [
-            ResultColumn(
-                rc.name, 
-                type_code=rc.type_.get_dbapi_type(), 
-                nullable=False
-            )
-            for rc in joined_table_cols
-        ]
-        return SchemaInfo(result_cols)
+        return SchemaInfo.from_join(left, right)
     
 def select(*entities: Union[Table, Column]) -> Select:
     return Select(*entities)

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -22,7 +22,6 @@ from normlite.notiondbapi import Error
 from normlite.notiondbapi.resultset import ResultSet
 from normlite.sql.schema import ColumnCollection
 
-import pdb
 from types import MappingProxyType
 from typing import Any, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING
 import collections.abc as collections_abc

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -87,42 +87,81 @@ def merge_inner_join_rows(
     onclause_column: Column,
     left_rows: list[tuple],
     right_rows: list[tuple],
+    isouter: bool = False
 ) -> list[tuple]:
     """Cross-product left rows with right rows whose object_id matches the
-    decoded relation list on each left row. Drops left rows whose relation
-    resolves to zero matching right rows (inner-join semantics)."""
+    decoded relation list on each left row.
+
+    Inner vs outer differ in exactly ONE place: what to do with a left row
+    that matched zero right rows. Inner drops it; outer rescues it with a
+    single None-filled row. Every left row that matched at least once is
+    treated identically by both kinds. So `isouter` is consulted at one site
+    only -- the per-row fallback below -- and nowhere else.
+
+    INVARIANT (per left row, not across the batch): a given left row
+    contributes exactly one None-filled row iff THAT row's foreign keys
+    matched zero right rows. This single predicate subsumes all three
+    zero-match shapes -- empty relation, all-dangling ids, and a lone
+    dangling id -- so none of them needs its own branch.
+    """
 
     merged_rows = []
 
     # prepare the getters
     relation_proc = onclause_column.type_.result_processor()
     get_oids = left_schema.column_getter(onclause_column.name)
+    get_left_oid = left_schema.column_getter("object_id")
     get_right_oid =  right_schema.column_getter("object_id")
 
     # construct a helper dictionary to contain {"id": <right_row>}
-    # then the check whether to merge the right row is o(1) (dictionary lookup)
+    # the dict answers "does THIS oid resolve?" in O(1). It does NOT answer
+    # "did this left row match anything?" -- that is a per-row aggregate
+    # (see `matched` below) and can only be known after the oid loop finishes.
     right_by_oid = {get_right_oid(rr): rr for rr in right_rows}
 
     # build the cross-product
     for left_row in left_rows:
         fk_oids = relation_proc(get_oids(left_row)) or []
+
+        # `matched` is reset per left row: it tracks whether THIS row found
+        # any partner. Truthiness is all we read -- a bool flag would do.
+        matched = []
         for fk_oid in fk_oids:
             right_row = right_by_oid.get(fk_oid)
             if right_row is None:
+                # dangling id: contributes no row of its own. Whether the row
+                # gets rescued is decided once, after the loop -- never here,
+                # because a later oid in this same row may still match.
                 continue
 
             merged_rows.append(
-                _project_inner_join(
+                _project_join_row(
                     left_schema,
                     right_schema,
-                    left_row, 
+                    left_row,
                     right_row
+                )
+            )
+
+            matched.append(get_left_oid(left_row))
+
+        # The ONLY place inner and outer diverge. Gated on `isouter`: under
+        # inner join a zero-match row is simply dropped (no fallback). Without
+        # this guard, None-fill would leak into inner join and break its
+        # drop-the-unmatched contract.
+        if not matched and isouter:
+            merged_rows.append(
+                _project_join_row(
+                    left_schema,
+                    right_schema,
+                    left_row,
+                    None
                 )
             )
 
     return merged_rows
 
-def _project_inner_join(
+def _project_join_row(
     left_schema: SchemaInfo,
     right_schema: SchemaInfo,
     left_row: tuple, 
@@ -135,16 +174,59 @@ def _project_inner_join(
             if lc.name != "object_id"
         ]
     )
-    right_projected = tuple(
-        [
-            right_row[right_schema.column_index(rc.name)] 
-            for rc in right_schema.columns 
-            if rc.name != "object_id"
-        ]
-    )
+    if right_row is not None:
+        right_projected = tuple(
+            [
+                right_row[right_schema.column_index(rc.name)] 
+                for rc in right_schema.columns 
+                if rc.name != "object_id"
+            ]
+        )
+    else:
+        right_projected = tuple(
+            [
+                None 
+                for rc in right_schema.columns 
+                if rc.name != "object_id"
+            ]
+        )
 
     return (*left_projected, *right_projected)
 
+def _right_side_passes(
+    merged_row, 
+    right_filter, 
+    left_width, 
+    right_cols: list[ResultColumn]
+) -> bool:
+    """Shape adapter to apply ``_Filter`` predicate coming from WHERE clause on right columns."""
+
+    from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
+    from normlite.notion_sdk.client import _Filter
+
+    type_mapper = {
+        DBAPITypeCode.NUMBER: "number",
+        DBAPITypeCode.NUMBER_WITH_COMMAS: "number",
+        DBAPITypeCode.NUMBER_DOLLAR: "number",
+        DBAPITypeCode.TITLE: "title",
+        DBAPITypeCode.RICH_TEXT: "rich_text",
+        DBAPITypeCode.CHECKBOX: "checkbox",
+        DBAPITypeCode.DATE: "date",
+        DBAPITypeCode.RELATION: "relation"
+    }
+
+    right_slice = merged_row[left_width:]
+    if all(c is None for c in right_slice):
+        return False        # phantom: NULL fails every right-side predicate
+
+    properties = {}
+
+    for col, cell in zip(right_cols, right_slice):
+        typ = type_mapper[col.type_code]
+        properties[col.name] = {"type": typ, **cell}
+    
+    page = {"properties": properties}
+    return _Filter(page, {"filter": right_filter}).eval()
 
 class HasTable(Protocol):
     """Mixin for DML statements"""
@@ -680,7 +762,7 @@ class Select(HasTable, ExecutableClauseElement):
         self._whereclause = WhereClause()
         self._order_by = OrderByClause()
 
-        # a tuple is than a list because it forces rebind-not-mutate discipline
+        # a tuple is better than a list because it forces rebind-not-mutate discipline
         # see how WhereClause and OrderByClause both encapsulate a tuple of clauses
         self._joins: tuple[Join] = ()
 
@@ -747,9 +829,11 @@ class Select(HasTable, ExecutableClauseElement):
 
         self._order_by = self._order_by.add(*clauses)
         return self
-
-    @generative
-    def join(self, onclause: ColumnExpressionArgument) -> Self:
+    
+    def _create_join(
+        self, onclause: ColumnExpressionArgument, 
+        isouter: bool = False
+    ) -> Join:
         if isinstance(onclause, Table):
             # syntactic sugar: search the left tables's column that has a relation to
             # this onclause table
@@ -805,8 +889,18 @@ class Select(HasTable, ExecutableClauseElement):
                 f"or BinaryExpression, got {type(onclause).__name__}"
             )
 
+        return Join(self._table, self._right, onclause, isouter)    
+
+    @generative
+    def join(self, onclause: ColumnExpressionArgument) -> Self:
         # mutate-vs-rebind: here you create a new tuple
-        self._joins = (*self._joins, Join(self._table, self._right, onclause))
+        self._joins = (*self._joins, self._create_join(onclause))
+        return self
+    
+    @generative
+    def outerjoin(self, onclause: ColumnExpressionArgument) -> Self:
+        # mutate-vs-rebind: here you create a new tuple
+        self._joins = (*self._joins, self._create_join(onclause, isouter=True))
         return self
     
     def _setup_execution(self, context: ExecutionContext) -> None:
@@ -888,8 +982,27 @@ class Select(HasTable, ExecutableClauseElement):
             context._join_right_schema,
             context._join.onclause, 
             context._join_left_rows, 
-            right_rows
+            right_rows,
+            isouter=context._join.isouter
         )
+
+        # filter the right rows if WHERE clause contains a condition on right columns
+        join_right_filter = context.join_right_filter
+        left_width = len([c for c in context._join_left_schema.columns if c.name != "object_id"])
+        right_cols = [c for c in context._join_right_schema.columns if c.name != "object_id"]
+        if join_right_filter is not None:
+            merged_rows = [
+                r
+                for r in merged_rows
+                if _right_side_passes(
+                    r,
+                    join_right_filter,
+                    left_width,
+                    right_cols
+                )
+            ]
+
+        # fill in the result cursor's result set    
         context._result_cursor._result_sets.append(
             ResultSet(
                 joined.as_sequence(),

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -17,19 +17,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+from normlite.notion_sdk.client import NotionError
 from normlite.notiondbapi import Error
+from normlite.notiondbapi.resultset import ResultSet
 from normlite.sql.schema import ColumnCollection
 
 import pdb
 from types import MappingProxyType
-from typing import Any, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Union, TYPE_CHECKING, Tuple
+from typing import Any, Callable, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING, Tuple
 import collections.abc as collections_abc
 
 import warnings
 from normlite.exceptions import ArgumentError
 from normlite.sql.base import Executable, ClauseElement, generative
 from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList, ColumnElement
-from normlite.sql.resultschema import SchemaInfo
+from normlite.sql.resultschema import ResultColumn, SchemaInfo
 from normlite.sql.type_api import Relation
 from normlite.sql.schema import Column
 
@@ -39,6 +41,97 @@ if TYPE_CHECKING:
     from normlite.engine.cursor import CursorResult
     from normlite.engine.base import Connection
     from normlite.engine.context import ExecutionContext
+    from normlite.notiondbapi.dbapi2 import DBAPIErrorHandlerType
+    from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection
+    from normlite.notiondbapi.dbapi2 import Cursor as DBAPICursor 
+
+def build_phase_two_batch(
+    left_schema: SchemaInfo,
+    onclause_column: Column,
+    left_rows: list[tuple],
+) -> list[dict]:
+    """Return deduplicated `pages.retrieve` path_params for phase 2."""
+
+    # build the bulk parameters
+    # one parameter for each page_id contained in the FK relation column stored in
+    # each page returned by the databases.query
+    # REMEMBER: A Relation column stores non-scalar values -> list[str]
+    seen: set[str] = set()
+    bulk_params: list[dict] = []
+
+    get_fk_col = left_schema.column_getter(onclause_column.name)
+    for row in left_rows:
+        oids = onclause_column.type_.result_processor()(get_fk_col(row)) or []
+        for oid in oids:
+            if oid not in seen:
+                seen.add(oid)
+                bulk_params.append({"path_params": {"page_id": oid}})
+
+    return bulk_params
+
+def merge_inner_join_rows(
+    left_schema: SchemaInfo,
+    right_schema: SchemaInfo,
+    onclause_column: Column,
+    left_rows: list[tuple],
+    right_rows: list[tuple],
+) -> list[tuple]:
+    """Cross-product left rows with right rows whose object_id matches the
+    decoded relation list on each left row. Drops left rows whose relation
+    resolves to zero matching right rows (inner-join semantics)."""
+
+    merged_rows = []
+
+    # prepare the getters
+    relation_proc = onclause_column.type_.result_processor()
+    get_oids = left_schema.column_getter(onclause_column.name)
+    get_right_oid =  right_schema.column_getter("object_id")
+
+    # construct a helper dictionary to contain {"id": <right_row>}
+    # then the check whether to merge the right row is o(1) (dictionary lookup)
+    right_by_oid = {get_right_oid(rr): rr for rr in right_rows}
+
+    # build the cross-product
+    for left_row in left_rows:
+        fk_oids = relation_proc(get_oids(left_row)) or []
+        for fk_oid in fk_oids:
+            right_row = right_by_oid.get(fk_oid)
+            if right_row is None:
+                continue
+
+            merged_rows.append(
+                _project_inner_join(
+                    left_schema,
+                    right_schema,
+                    left_row, 
+                    right_row
+                )
+            )
+
+    return merged_rows
+
+def _project_inner_join(
+    left_schema: SchemaInfo,
+    right_schema: SchemaInfo,
+    left_row: tuple, 
+    right_row: tuple
+) -> tuple:
+    left_projected = tuple(
+        [
+            left_row[left_schema.column_index(lc.name)] 
+            for lc in left_schema.columns 
+            if lc.name != "object_id"
+        ]
+    )
+    right_projected = tuple(
+        [
+            right_row[right_schema.column_index(rc.name)] 
+            for rc in right_schema.columns 
+            if rc.name != "object_id"
+        ]
+    )
+
+    return (*left_projected, *right_projected)
 
 
 class HasTable(Protocol):
@@ -553,6 +646,7 @@ class OrderByClause(HasExpression, ClauseElement):
 
 class Select(HasTable, ExecutableClauseElement):
     __visit_name__ = 'select'
+    
     is_select = True
 
     _projection: ReadOnlyColumnCollection
@@ -682,19 +776,112 @@ class Select(HasTable, ExecutableClauseElement):
         # mutate-vs-rebind: here you create a new tuple
         self._joins = (*self._joins, Join(self._table, self._right, onclause))
         return self
-
+    
     def _setup_execution(self, context: ExecutionContext) -> None:
-        # guard against execution if joins are non-empty
-        if self._joins:
-            raise NotImplementedError("Join-clause implemented in future slice: #304")
+        # guard against execution if joins are empty
+        if not self._joins:
+            return
         
-        # nothing to do for select without join clause
-        pass
+        # phase 1: Retrieve all rows of the left table in the join
+        elem = context.invoked_stmt
+
+        # 1. prepare schema for compiled query
+        context._join = self._joins[0]
+        context._join_left_schema = SchemaInfo.from_table(
+            context._join.left,
+            execution_names=context.compiled.fetch_columns(),
+            projected_names=[c.name for c in context._join.left.uc]  
+        )
+        context._cursor._inject_description(
+            context._join_left_schema.as_sequence()
+        )
+
+        # execute the compiled query
+        context.engine.do_execute(
+            context._cursor,
+            context.operation,
+            context.parameters
+        )
+
+        context._join_left_rows = context._cursor.fetchall()
+
+        # prepare phase 2: retrieve left table rows 
+        # build parameters for pages.retrieve
+        result_cursor = context.connection._engine.raw_connection().cursor()
+        right_schema: SchemaInfo = SchemaInfo.from_table(
+            context._join.right,
+            execution_names=context.compiled.fetch_columns(),
+            projected_names=[c.name for c in context._join.right.uc]    
+        )
+        result_cursor._inject_description(right_schema.as_sequence())
+        result_cursor.errorhandler = _join_errorhandler
+        context._join_right_schema = right_schema
+
+        # build the bulk parameters
+        # one parameter for each page_id contained in the FK relation column stored in
+        # each page returned by the databases.query
+        # REMEMBER: A Relation column stores non-scalar values -> list[str]
+        onclause_column = context._join.onclause
+        bulk_params = build_phase_two_batch(
+            context._join_left_schema,
+            onclause_column,
+            context._join_left_rows
+        )
+
+        # staged cursor will contain 1 result set for each retrieved row
+        context._staged_result_cursor = result_cursor
+        context.bulk_operation = {
+            "endpoint": "pages",
+            "request": "retrieve"
+        }
+
+        context.bulk_parameters = bulk_params
 
     def _finalize_execution(self, context: ExecutionContext) -> None:
-        # nothing to be finalized
-        pass
+        # guard against execution if joins are empty
+        if not self._joins:
+            return
 
+        # context._result_cursor will hold the joined rows
+        joined = self._build_joined_schema(context)
+        context._result_cursor = context.engine.raw_connection().cursor()
+
+        # merge left rows with the corresponding right rows
+        # _staged_cursor has multiple result sets, one for each retrieved right row
+        right_rows = [r for r in context._staged_result_cursor._iter_all()]
+        
+        # construct the inner join and add the result to the cursor
+        merged_rows = merge_inner_join_rows(
+            context._join_left_schema,
+            context._join_right_schema,
+            context._join.onclause, 
+            context._join_left_rows, 
+            right_rows
+        )
+        context._result_cursor._result_sets.append(
+            ResultSet(
+                joined.as_sequence(),
+                "page",
+                merged_rows
+            )
+        )
+
+    def _build_joined_schema(self, context: ExecutionContext) -> SchemaInfo:
+        # the result cursor has the schema of a joined table
+        # the joined table has all left and right table's columns 
+        left = context._join.left
+        right = context._join.right
+        joined_table_cols = [*left.uc, *right.uc]
+        result_cols = [
+            ResultColumn(
+                rc.name, 
+                type_code=rc.type_.get_dbapi_type(), 
+                nullable=False
+            )
+            for rc in joined_table_cols
+        ]
+        return SchemaInfo(result_cols)
+    
 def select(*entities: Union[Table, Column]) -> Select:
     return Select(*entities)
         
@@ -896,3 +1083,27 @@ class Join(ClauseElement):
         self.right = right
         self.onclause = onclause
         self.isouter = isouter
+
+
+def _join_errorhandler(
+    connection: DBAPIConnection, 
+    cursor: DBAPICursor, 
+    errorclass: Type[BaseException],
+    errorvalue: BaseException
+) -> None:
+    """Errorhandler for the inner-join staged result cursor.
+
+    Silences `object_not_found` from `pages.retrieve` (ADR-0002 lax-FK semantics:
+    a dangling relation entry is an absent reference, not an error). All other
+    errors propagate via the default DBAPI raise path.
+    """
+    cause = errorvalue.__cause__
+    if isinstance(cause, NotionError) and cause.code == "object_not_found":
+        # Dangling-FK / lax-reference semantics (ADR-0002):
+        # missing pages are treated as absent references
+        # INNER JOIN silently drops left rows whose relation list resolves 
+        # to zero existing right rows
+        return                       
+
+    raise errorvalue                 # propagate everything else
+

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -28,11 +28,13 @@ import collections.abc as collections_abc
 import warnings
 from normlite.exceptions import ArgumentError
 from normlite.sql.base import Executable, ClauseElement, generative
-from normlite.sql.elements import BindParameter, BooleanClauseList, ColumnElement
+from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList, ColumnElement
 from normlite.sql.resultschema import SchemaInfo
+from normlite.sql.type_api import Relation
+from normlite.sql.schema import Column
 
 if TYPE_CHECKING:
-    from normlite.sql.schema import Column, Table, ReadOnlyColumnCollection
+    from normlite.sql.schema import Table, ReadOnlyColumnCollection
     from normlite.engine.interfaces import _CoreAnyExecuteParams
     from normlite.engine.cursor import CursorResult
     from normlite.engine.base import Connection
@@ -556,6 +558,8 @@ class Select(HasTable, ExecutableClauseElement):
     _projection: ReadOnlyColumnCollection
     """The column names to be projected in this select statement."""
 
+    _right: Optional[Table] = None
+
     def __init__(self, *entities: Union[Table, Column]):
         from normlite.sql.schema import Column, Table
 
@@ -570,6 +574,10 @@ class Select(HasTable, ExecutableClauseElement):
         self._whereclause = WhereClause()
         self._order_by = OrderByClause()
 
+        # a tuple is than a list because it forces rebind-not-mutate discipline
+        # see how WhereClause and OrderByClause both encapsulate a tuple of clauses
+        self._joins: tuple[Join] = ()
+
         if len(entities) == 1 and isinstance(entities[0], Table):
             # a Table object has been provided
             table = entities[0]
@@ -578,6 +586,14 @@ class Select(HasTable, ExecutableClauseElement):
             # project all columns
             self._projection = self._table.c
             return
+        
+        if len(entities) == 2:
+            if isinstance(entities[0], Table) and isinstance(entities[1], Table):
+                # select columns from multiple tables: join case
+                self._table = entities[0]
+                self._right = entities[1]
+                self._projection = ColumnCollection().as_readonly()
+                return 
 
         # A list of columns has been provided
         tables = set()
@@ -626,8 +642,53 @@ class Select(HasTable, ExecutableClauseElement):
         self._order_by = self._order_by.add(*clauses)
         return self
 
+    @generative
+    def join(self, onclause: ColumnElement) -> Self:
+        if isinstance(onclause, BinaryExpression):
+            inner_col = onclause.column
+            if not isinstance(inner_col.type_, Relation):
+                raise ArgumentError(
+                    f"join() onclause must be a BinaryExpression with a Relation column, got '{inner_col.name}' "
+                    f"(type: {type(inner_col.type_).__name__})"
+                )
+    
+            if inner_col.parent is not self._table:
+                message = f"""
+                    join() onclause must a BinaryExpression and its column '{inner_col.name}' 
+                    must belong to left table '{self._table.name}',
+                    got column '{inner_col.name}' on table '{inner_col.parent.name}'
+                """
+                raise ArgumentError(message)
+        elif isinstance(onclause, Column):
+            if not isinstance(onclause.type_, Relation):
+                    raise ArgumentError(
+                        f"join() onclause must be a Relation column, got '{onclause.name}' "
+                        f"(type: {type(onclause.type_).__name__})"
+                    )
+        
+            if onclause.parent is not self._table:
+                message = f"""
+                    join() onclause must belong to left table '{self._table.name}',
+                    got column '{onclause.name}' on table '{onclause.parent.name}'
+                """
+                raise ArgumentError(message)
+        
+        else: 
+            raise ArgumentError(
+                f"join() onclause must be a Column "
+                f"or BinaryExpression, got {type(onclause).__name__}"
+            )
+
+        # mutate-vs-rebind: here you create a new tuple
+        self._joins = (*self._joins, Join(self._table, self._right, onclause))
+        return self
+
     def _setup_execution(self, context: ExecutionContext) -> None:
-        # nothing to be setup
+        # guard against execution if joins are non-empty
+        if self._joins:
+            raise NotImplementedError("Join-clause implemented in future slice: #304")
+        
+        # nothing to do for select without join clause
         pass
 
     def _finalize_execution(self, context: ExecutionContext) -> None:
@@ -804,3 +865,34 @@ class Update(ValuesBase):
 
 def update(table: Table) -> Update:
     return Update(table)
+
+class Join(ClauseElement):
+    """Represent a ``JOIN`` construct between two tables.
+    
+    .. versionadded:: 0.11.0
+    """
+    __visit_name__ = "join"
+    
+    left: Table
+    """Left side of the ``JOIN``"""
+
+    right: Table
+    """Right side of the ``JOIN``"""
+
+    onclause: Column
+    """The column representing the ``ON`` clause of the join"""
+
+    isouter: bool
+    """if True, render a ``LEFT OUTER JOIN``, instead of ``JOIN``"""
+
+    def __init__(
+        self,
+        left: Table,
+        right: Table,
+        onclause: Column,
+        isouter: bool = False
+    ):
+        self.left = left
+        self.right = right
+        self.onclause = onclause
+        self.isouter = isouter

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -24,7 +24,7 @@ from normlite.sql.schema import ColumnCollection
 
 import pdb
 from types import MappingProxyType
-from typing import Any, Callable, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING, Tuple
+from typing import Any, Mapping, NoReturn, Optional, Protocol, Self, Sequence, Type, Union, TYPE_CHECKING
 import collections.abc as collections_abc
 
 import warnings
@@ -33,17 +33,29 @@ from normlite.sql.base import Executable, ClauseElement, generative
 from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList, ColumnElement
 from normlite.sql.resultschema import ResultColumn, SchemaInfo
 from normlite.sql.type_api import Relation
-from normlite.sql.schema import Column
+from normlite.sql.schema import Column, Table
 
 if TYPE_CHECKING:
-    from normlite.sql.schema import Table, ReadOnlyColumnCollection
+    from normlite.sql.schema import ReadOnlyColumnCollection
     from normlite.engine.interfaces import _CoreAnyExecuteParams
     from normlite.engine.cursor import CursorResult
     from normlite.engine.base import Connection
     from normlite.engine.context import ExecutionContext
-    from normlite.notiondbapi.dbapi2 import DBAPIErrorHandlerType
     from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection
     from normlite.notiondbapi.dbapi2 import Cursor as DBAPICursor 
+
+ColumnExpressionArgument = Union[
+    BinaryExpression,
+    ColumnElement,
+    Table,
+]
+"""Column expression argument for :meth:`Select.join`.
+
+This type represents the options for the ``onclause`` argument in a JOIN ON clause.
+It enables to implement syntactic surgar expressions for the :meth:`Select.join` method.
+
+.. versionadded:: 0.11.0
+"""
 
 def build_phase_two_batch(
     left_schema: SchemaInfo,
@@ -737,7 +749,27 @@ class Select(HasTable, ExecutableClauseElement):
         return self
 
     @generative
-    def join(self, onclause: ColumnElement) -> Self:
+    def join(self, onclause: ColumnExpressionArgument) -> Self:
+        if isinstance(onclause, Table):
+            # syntactic sugar: search the left tables's column that has a relation to
+            # this onclause table
+            reftable = onclause
+            fkcs = self._table.foreign_keys
+            relation_cols = [fk.column for fk in fkcs if fk.reftable is reftable]
+            if not relation_cols:
+                # the table supplied in onclause must be a referenced table in the left table's foreign keys
+                hint = ""
+                if reftable.name in self._table.metadata:
+                    hint = (f" (a table named '{reftable.name}' exists in metadata, "
+                            f"but the instance you passed is a different object — "
+                            f"was it built under another MetaData?)")
+                raise ArgumentError(
+                    f"Table '{reftable.name}' is not a referenced table in "
+                    f"'{self._table.name}' foreign keys.{hint}"
+                )
+
+            onclause = relation_cols[0]
+
         if isinstance(onclause, BinaryExpression):
             inner_col = onclause.column
             if not isinstance(inner_col.type_, Relation):

--- a/src/normlite/sql/resultschema.py
+++ b/src/normlite/sql/resultschema.py
@@ -40,7 +40,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 from normlite._constants import SpecialColumns
 from normlite.exceptions import InvalidRequestError, NoSuchColumnError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
-from normlite.sql.schema import Table
+from normlite.sql.schema import Column, Table
 
 def _merge_names(
     execution_names: Optional[Sequence[str]],
@@ -107,7 +107,7 @@ class SchemaInfo:
         Args:
             table (Table): The table representive the authoritative source of the schema.
             execution_names (Optional[Sequence[str]]): The ordered projection list of system columns (Notion key values) required for statement execution.
-            projected_names (Optional[Sequence[str]]): The ordered projection list of columns (Notion key valuses **and** properties) the user wants to have in the returned rows.
+            projected_names (Optional[Sequence[str]]): The ordered projection list of columns (Notion key values **and** properties) the user wants to have in the returned rows.
 
         Raises:
             NoSuchColumnError: If any of the column names in ``projection_names`` could not be found in the table.
@@ -143,6 +143,34 @@ class SchemaInfo:
 
         return cls(tuple(result_columns))
     
+    @classmethod
+    def from_join(
+        cls,
+        left: Table,
+        right: Table,        
+    ) -> SchemaInfo:
+        
+        fqname_by_col: dict[Column, str] = {}
+        for lc in left.uc:
+            if lc.name in right.uc:
+                # colliding column names: add both left and right columns
+                # with fully qualified names
+                fqname_by_col[lc] = f"{lc.parent.name}.{lc.name}"
+                rc = right.uc[lc.name]
+                fqname_by_col[rc] = f"{rc.parent.name}.{rc.name}"
+
+        joined_table_cols = [*left.uc, *right.uc]
+        result_cols = [
+            ResultColumn(
+                # take the FQ-name if it's a colliding column
+                fqname_by_col.get(rc, rc.name), 
+                type_code=rc.type_.get_dbapi_type(), 
+                nullable=False
+            )
+            for rc in joined_table_cols
+        ]
+        return SchemaInfo(result_cols)
+        
     def as_sequence(self) -> Sequence[tuple]:
         """Provide the description for DBAPI cursors.
         

--- a/src/normlite/sql/resultschema.py
+++ b/src/normlite/sql/resultschema.py
@@ -36,7 +36,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence
-
 from normlite._constants import SpecialColumns
 from normlite.exceptions import InvalidRequestError, NoSuchColumnError
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
@@ -91,7 +90,6 @@ class SchemaInfo:
         compare=False,
     )
 
-
     @classmethod
     def from_table(
         cls,
@@ -145,21 +143,32 @@ class SchemaInfo:
     
     @classmethod
     def from_join(
-        cls,
+        cls, 
         left: Table,
-        right: Table,        
+        right: Table,
+        *entities: Column
     ) -> SchemaInfo:
-        
         fqname_by_col: dict[Column, str] = {}
-        for lc in left.uc:
-            if lc.name in right.uc:
-                # colliding column names: add both left and right columns
-                # with fully qualified names
-                fqname_by_col[lc] = f"{lc.parent.name}.{lc.name}"
-                rc = right.uc[lc.name]
-                fqname_by_col[rc] = f"{rc.parent.name}.{rc.name}"
 
-        joined_table_cols = [*left.uc, *right.uc]
+        # find colliding column names:
+        # same name in entities
+        seen = set()
+        colliding: dict[str, list[Column]] = {}
+        for ent in entities:
+            if ent.name not in colliding:
+                colliding[ent.name] = [ent]
+            else:
+                colliding[ent.name].append(ent)
+
+        # fully qualify names for colliding only
+        for cols in colliding.values():
+            if len(cols) == 1:
+                # skip, only column only does not need qualification
+                continue
+
+            for ent in cols:
+                fqname_by_col[ent] = f"{ent.parent.name}.{ent.name}"
+
         result_cols = [
             ResultColumn(
                 # take the FQ-name if it's a colliding column
@@ -167,7 +176,7 @@ class SchemaInfo:
                 type_code=rc.type_.get_dbapi_type(), 
                 nullable=False
             )
-            for rc in joined_table_cols
+            for rc in entities
         ]
         return SchemaInfo(result_cols)
         
@@ -221,3 +230,14 @@ class SchemaInfo:
             return row[idx]
 
         return getter
+    
+    def __contains__(self, key: str) -> bool:
+        if not isinstance(key, str):
+            raise ArgumentError(
+                "__contains__ requires a string argument"
+            )
+        
+        if key not in self._index_map:
+            return False
+        
+        return True

--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -595,11 +595,25 @@ class Table(HasIdentifier):
         self._sys_columns["object_id"]._value = id_
     
     def add_constraint(self, constraint: Constraint) -> None:
-        """Add a constraint to this table."""
+        """Add a constraint to this table.
+        
+        .. versionchanged:: 0.11.0
+            This method now enforces the Notion's data model invariant: 
+            No two relation properties pointing to the same database. 
+        """
         constraint._set_parent(self)
-        self._constraints.add(constraint)
         if isinstance(constraint, ForeignKeyConstraint):
-            self.foreign_keys.add(constraint)
+            existing = [
+                fk 
+                for fk in self.foreign_keys 
+                if fk.reftable is constraint.reftable
+            ]
+            if existing:
+                raise ArgumentError(
+                    f"Table '{self.name}' already has a relation to "
+                    f"'{constraint.reftable.name}'; Notion forbids two."
+                )
+        self._constraints.add(constraint)
 
     def append_column(self, column: Column):
         """Append a column to this table.
@@ -1167,7 +1181,7 @@ class ForeignKeyConstraint(Constraint):
     constraint. 
 
     .. note::
-        In the Notion's data model, a :class:`normlite.sql.type_api.Relation` propery always links to exactly one target database.
+        In the Notion's data model, a :class:`normlite.sql.type_api.Relation` property always links to exactly one target database.
         There is no concept of a multi-column composite relation in the Notion API.
 
     .. versionadded:: 0.11.0 

--- a/src/normlite/sql/schema.py
+++ b/src/normlite/sql/schema.py
@@ -921,7 +921,6 @@ class Table(HasIdentifier):
         return "Table(%s)" % ", ".join(
             [repr(self.name)]
             + [repr(x) for x in self.columns]
-            + [repr(x) for x in self._sys_columns]
         )
     
 class ColumnCollection:

--- a/src/normlite/sql/type_api.py
+++ b/src/normlite/sql/type_api.py
@@ -705,7 +705,6 @@ class DateTimeRange:
         # Case 3: datetime
         # -----------------------------------------
         if isinstance(other, datetime):
-            pdb.set_trace()
             try:
                 other_dtr = DateTimeRange(other)
             except Exception:

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -425,3 +425,110 @@ def test_join_propagates_non_404_retrieve_error(engine: Engine, monkeypatch):
     assert isinstance(cause, NotionError)
     assert cause.code == "internal_server_error"
     assert cause.status_code == 500
+
+def test_join_qualifies_colliding_column_names_by_table(engine: Engine):
+    # Arrange: two tables that BOTH declare a `name` column, FK-linked.
+    # `students.advisor` points at an `instructors` row. A bare merged schema
+    # would emit two columns both literally named "name" — and because the
+    # cursor metadata keys columns by name, the right side would silently
+    # clobber the left. The join must instead disambiguate on collision using
+    # each table's public name.
+    metadata = MetaData()
+    instructors = Table(
+        "instructors",
+        metadata,
+        Column("name", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("advisor", Relation(), ForeignKey("instructors.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        advisor_oid = (
+            connection.execute(
+                insert(instructors)
+                .values(name="Vincenzo Galilei")
+                .returning(instructors.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                advisor=[advisor_oid],
+            )
+        )
+
+        # Act: join the two tables, both of which carry a `name`.
+        result = connection.execute(
+            select(students, instructors).join(students.c.advisor)
+        )
+        row = result.fetchall()[0]
+
+    # Assert: both `name`s are reachable under table-qualified keys, with no
+    # bare-`name` shadow collapsing the two into one.
+    keys = set(row.keys())
+    assert "students.name" in keys
+    assert "instructors.name" in keys
+    assert "name" not in keys
+
+    m = row.mapping()
+    assert m["students.name"] == "Galileo Galilei"
+    assert m["instructors.name"] == "Vincenzo Galilei"
+
+
+def test_join_projects_columns_from_both_tables(engine: Engine):
+    # Arrange: an FK-linked pair with DISTINCT column names, so qualification
+    # never enters the picture. The point of this behavior is narrower: a SELECT
+    # that lists columns drawn from BOTH joined tables must be expressible and
+    # must surface every projected column, each carrying its own side's value.
+    metadata = MetaData()
+    instructors = Table(
+        "instructors",
+        metadata,
+        Column("director", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("advisor", Relation(), ForeignKey("instructors.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        advisor_oid = (
+            connection.execute(
+                insert(instructors)
+                .values(director="Vincenzo Galilei")
+                .returning(instructors.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                advisor=[advisor_oid],
+            )
+        )
+
+        # Act: project one column from each side of the join.
+        result = connection.execute(
+            select(students.c.name, instructors.c.director).join(students.c.advisor)
+        )
+        row = result.fetchall()[0]
+
+    # Assert: both projected columns are reachable, each with its own table's value.
+    keys = set(row.keys())
+    assert "name" in keys
+    assert "director" in keys
+
+    m = row.mapping()
+    assert m["name"] == "Galileo Galilei"
+    assert m["director"] == "Vincenzo Galilei"

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -1,10 +1,11 @@
-import pdb
 import uuid
 
 import pytest
 
 from normlite import Relation, ForeignKey
 from normlite.engine.base import Engine
+from normlite.notiondbapi import DatabaseError
+from normlite.notion_sdk.client import InMemoryNotionClient, NotionError
 from normlite.sql.dml import insert, select
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import String
@@ -359,3 +360,68 @@ def test_right_side_is_empty_drops_absent_entity(engine: Engine):
     # Assert: the absent entity is dropped
     no_pairs = {(row.name, row.title) for row in no_rows}
     assert no_pairs == set()
+
+
+def test_join_propagates_non_404_retrieve_error(engine: Engine, monkeypatch):
+    # Differential to the dangling-reference tests above: a phase-2
+    # `pages.retrieve` that 404s (`object_not_found`) is benign and silenced
+    # (ADR-0002 lax-FK: a dangling relation entry is an absent reference, not
+    # an error). But ANY OTHER retrieve error — here a 500 server error on a
+    # legitimately-referenced right page — must NOT be swallowed: it propagates
+    # via `_join_errorhandler`'s default raise path as a DBAPI DatabaseError.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        # Seed a genuine match so phase-2 actually issues a retrieve on a real,
+        # resolvable right page (not a dangling id that would 404).
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Make phase-2 `pages.retrieve` fail with a non-404 server error AFTER
+        # seeding, so only the join's retrieve is affected.
+        def boom(self, path_params=None, query_params=None, payload=None):
+            raise NotionError(
+                "Internal server error",
+                status_code=500,
+                code="internal_server_error",
+            )
+
+        monkeypatch.setattr(InMemoryNotionClient, "pages_retrieve", boom)
+
+        # Act + Assert: the server error propagates rather than being silenced.
+        with pytest.raises(DatabaseError) as exc_info:
+            connection.execute(
+                select(students, courses).outerjoin(students.c.enrolled_in)
+            )
+
+    # The propagated DBAPI error carries the original NotionError as its cause,
+    # and it is the non-404 we injected — not an accidental silencing/other path.
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, NotionError)
+    assert cause.code == "internal_server_error"
+    assert cause.status_code == 500

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -362,6 +362,68 @@ def test_right_side_is_empty_drops_absent_entity(engine: Engine):
     no_pairs = {(row.name, row.title) for row in no_rows}
     assert no_pairs == set()
 
+def test_right_side_filter_under_narrowed_projection_keeps_genuine_match(engine: Engine):
+    # Arrange: same FK-linked two-table fixture as the full-projection
+    # right-side-filter test — Galileo enrolled in a real course, Phantom
+    # Student pointing at a dangling id. The ONLY difference here is the
+    # projection: instead of select(students, courses) we narrow to a
+    # column list (one left col, one right col) and THEN layer the same
+    # right-side WHERE on courses.title. The genuine match (Galileo →
+    # Astronomy) satisfies is_not_empty(), so a correct filter must KEEP it.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    bogus_course_oid = str(uuid.uuid4())  # never inserted -> dangling reference
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Phantom Student",
+                enrolled_in=[bogus_course_oid],
+            )
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Act: NARROWED projection (column list, not whole tables) + the
+        # right-side filter on courses.title.
+        result = connection.execute(
+            select(students.c.name, courses.c.title)
+            .outerjoin(students.c.enrolled_in)
+            .where(courses.c.title.is_not_empty())
+        )
+        rows = result.fetchall()
+
+    # Assert: the genuine match survives. (Phantom's dangling row is
+    # None-filled and correctly fails the right-side filter.)
+    pairs = {(row.name, row.title) for row in rows}
+    assert pairs == {("Galileo Galilei", "Astronomy")}
+
 
 def test_join_propagates_non_404_retrieve_error(engine: Engine, monkeypatch):
     # Differential to the dangling-reference tests above: a phase-2

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -1,3 +1,4 @@
+import pdb
 import uuid
 
 import pytest
@@ -527,6 +528,64 @@ def test_join_projects_columns_from_both_tables(engine: Engine):
     # Assert: both projected columns are reachable, each with its own table's value.
     keys = set(row.keys())
     assert "name" in keys
+    assert "director" in keys
+
+    m = row.mapping()
+    assert m["name"] == "Galileo Galilei"
+    assert m["director"] == "Vincenzo Galilei"
+
+def test_join_keeps_projected_name_bare_when_collision_is_unprojected(engine: Engine):
+    # Arrange: `name` exists on BOTH tables, but only as a TABLE-level
+    # coincidence -- on `instructors` it is a plain (non-title) property that
+    # the query never asks for. The SELECT projects `students.name` and
+    # `instructors.director`; `instructors.name` is NOT projected. There is
+    # therefore no collision *in the projection*, so the surviving `name` key
+    # must stay BARE. Qualifying it (`students.name`) would be over-
+    # qualification driven by the table schemas rather than by what was asked.
+    metadata = MetaData()
+    instructors = Table(
+        "instructors",
+        metadata,
+        Column("director", String(is_title=True)),
+        Column("name", String()),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("advisor", Relation(), ForeignKey("instructors.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        advisor_oid = (
+            connection.execute(
+                insert(instructors)
+                .values(director="Vincenzo Galilei", name="Pisa Cathedral")
+                .returning(instructors.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                advisor=[advisor_oid],
+            )
+        )
+
+        # Act: project `name` from ONE side only, alongside the other side's
+        # `director`. The unprojected `instructors.name` is the collision bait.
+        result = connection.execute(
+            select(students.c.name, instructors.c.director).join(students.c.advisor)
+        )
+        row = result.fetchall()[0]
+
+    # Assert: the projected `name` surfaces under its BARE key (no ambiguity to
+    # resolve), and is NOT over-qualified to `students.name`.
+    keys = set(row.keys())
+    assert "name" in keys
+    assert "students.name" not in keys
     assert "director" in keys
 
     m = row.mapping()

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -1,0 +1,180 @@
+import pdb
+import uuid
+
+import pytest
+
+from normlite import Relation, ForeignKey
+from normlite.engine.base import Engine
+from normlite.sql.dml import insert, select
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import String
+
+
+def test_inner_join_pairs_left_and_right_rows(engine: Engine):
+    # --- Arrange: two FK-linked tables ---
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        # seed one course, capture its object_id via RETURNING
+        course_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        # seed one student linked to that course
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[course_oid],
+            )
+        )
+
+        # execute the join
+        result = connection.execute(
+            select(students, courses).join(students.c.enrolled_in)
+        )
+        rows = result.fetchall()
+
+    # --- Assert: exactly one paired row, both sides' user columns present ---
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.name == "Galileo Galilei"
+    assert row.title == "Astronomy"
+
+def test_inner_join_emits_one_pair_per_left_row_when_each_points_at_a_distinct_right_row(
+    engine: Engine,
+):
+    # Arrange: two students, each enrolled in a *different* course.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+        physics_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Physics")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+        connection.execute(
+            insert(students).values(
+                name="Isaac Newton",
+                enrolled_in=[physics_oid],
+            )
+        )
+
+        # Act
+        result = connection.execute(
+            select(students, courses).join(students.c.enrolled_in)
+        )
+        rows = result.fetchall()
+
+    # Assert: both pairings present (order intentionally not asserted).
+    pairs = {(row.name, row.title) for row in rows}
+    assert pairs == {
+        ("Galileo Galilei", "Astronomy"),
+        ("Isaac Newton", "Physics"),
+    }
+
+def test_inner_join_silently_drops_left_rows_whose_relation_targets_no_existing_right_page(
+    engine: Engine,
+):
+    # Arrange: two students. One enrolled in a real course; one whose relation
+    # points at a synthetic page id that was never inserted.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    bogus_course_oid = str(uuid.uuid4())  # nothing in `courses` will match this
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Phantom Student",
+                enrolled_in=[bogus_course_oid],
+            )
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Act
+        result = connection.execute(
+            select(students, courses).join(students.c.enrolled_in)
+        )
+        rows = result.fetchall()
+
+    # Assert: the dangling reference is silently dropped; the valid pair still appears.
+    pairs = {(row.name, row.title) for row in rows}
+    assert pairs == {("Galileo Galilei", "Astronomy")}
+

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -178,3 +178,184 @@ def test_inner_join_silently_drops_left_rows_whose_relation_targets_no_existing_
     pairs = {(row.name, row.title) for row in rows}
     assert pairs == {("Galileo Galilei", "Astronomy")}
 
+def test_outer_join_keeps_left_rows_whose_relation_targets_no_existing_right_page(
+    engine: Engine,
+):
+    # Arrange: two students. One enrolled in a real course; one whose relation
+    # points at a synthetic page id that was never inserted (dangling FK).
+    # Mirrors the inner-join drop test — same fixture, opposite contract:
+    # under OUTER join the dangling left row survives, right side None-filled.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    bogus_course_oid = str(uuid.uuid4())  # nothing in `courses` will match this
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Phantom Student",
+                enrolled_in=[bogus_course_oid],
+            )
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Act: outer join over the same FK relation.
+        result = connection.execute(
+            select(students, courses).outerjoin(students.c.enrolled_in)
+        )
+        rows = result.fetchall()
+
+    # Assert: BOTH students survive. Galileo is paired with his course;
+    # Phantom's dangling reference is preserved with the right side None-filled.
+    pairs = {(row.name, row.title) for row in rows}
+    assert pairs == {
+        ("Galileo Galilei", "Astronomy"),
+        ("Phantom Student", None),
+    }
+
+def test_right_side_filter_on_outer_join_drops_none_filled_rows(engine: Engine):
+    # Arrange: the same two-student fixture as the outer-join preservation test —
+    # Galileo enrolled in a real course, Phantom Student pointing at a dangling id.
+    # Under a bare outer join BOTH survive (Phantom None-filled). Here we layer a
+    # WHERE on a RIGHT-side column (courses.title) on top of the outer join: the
+    # None-filled row's title is None, so it must fail the filter and be dropped —
+    # while the real match stays. This is the slice-5 ↔ slice-6 interaction:
+    # the right-side predicate is answered client-side, after the join.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    bogus_course_oid = str(uuid.uuid4())  # never inserted -> dangling reference
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Phantom Student",
+                enrolled_in=[bogus_course_oid],
+            )
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Act: outer join, then a right-side filter on courses.title.
+        result = connection.execute(
+            select(students, courses)
+            .outerjoin(students.c.enrolled_in)
+            .where(courses.c.title.is_not_empty())
+        )
+        rows = result.fetchall()
+
+    # Assert: the None-filled Phantom row fails the right-side filter and is
+    # dropped; only the genuine match survives.
+    pairs = {(row.name, row.title) for row in rows}
+    assert pairs == {("Galileo Galilei", "Astronomy")}
+
+def test_right_side_is_empty_drops_absent_entity(engine: Engine):
+    # Arrange: As documented in ADR-0005, a right-side is_empty() drops the
+    # phantom (absent entity) — is_empty is NOT IS NULL. Single-sided: the
+    # present-entity-with-empty-title KEEP-side is currently unconstructable
+    # (String.bind_processor never emits {title: []}), so this test only pins
+    # the drop side. See memory project_unreachable_empty_title_boundary.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    bogus_course_oid = str(uuid.uuid4())  # never inserted -> dangling reference
+
+    with engine.connect() as connection:
+        astronomy_oid = (
+            connection.execute(
+                insert(courses)
+                .values(title="Astronomy")
+                .returning(courses.c.object_id)
+            )
+            .first()
+            .object_id
+        )
+
+        connection.execute(
+            insert(students).values(
+                name="Phantom Student",
+                enrolled_in=[bogus_course_oid],
+            )
+        )
+        connection.execute(
+            insert(students).values(
+                name="Galileo Galilei",
+                enrolled_in=[astronomy_oid],
+            )
+        )
+
+        # Act: outer join, then a right-side filter on courses.title.
+        result = connection.execute(
+            select(students, courses)
+            .outerjoin(students.c.enrolled_in)
+            .where(courses.c.title.is_empty())
+        )
+        no_rows = result.fetchall()
+
+
+    # Assert: the absent entity is dropped
+    no_pairs = {(row.name, row.title) for row in no_rows}
+    assert no_pairs == set()

--- a/tests/unit/engine/test_join_strategy.py
+++ b/tests/unit/engine/test_join_strategy.py
@@ -1,0 +1,151 @@
+import pdb
+
+import pytest
+
+from normlite import Relation, ForeignKey
+from normlite.sql.dml import build_phase_two_batch
+from normlite.sql.resultschema import SchemaInfo
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import String
+
+
+def test_build_phase_two_batch_dedups_target_ids_preserving_first_seen_order():
+    # Arrange: a left schema with a Relation FK column whose values are
+    # `list[str]` of target page ids — exactly the shape phase-1 leaves
+    # in the cursor after fetchall().
+    metadata = MetaData()
+    Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    onclause = students.c.enrolled_in
+
+    left_schema = SchemaInfo.from_table(
+        students,
+        execution_names=[students.c.object_id.name],
+        projected_names=[c.name for c in students.uc],
+    )
+
+    # Three students. Two share course "c-astro"; one points at "c-physics".
+    # The third row repeats "c-astro" again (intra-row + inter-row dup).
+    name_idx = left_schema.column_index("name")
+    enrolled_idx = left_schema.column_index("enrolled_in")
+    object_id_idx = left_schema.column_index("object_id")
+
+    def row(name: str, oids: list[str], oid: str) -> tuple:
+        cells = [None] * len(left_schema.columns)
+        cells[name_idx] = {"title": name}
+        cells[enrolled_idx] = {"relation": oids}
+        cells[object_id_idx] = oid
+        return tuple(cells)
+
+    left_rows = [
+        row("Galileo Galilei", [{"id":"c-astro"}],                     "s-1"),
+        row("Isaac Newton",    [{"id": "c-physics"}],                  "s-2"),
+        row("Marie Curie",     [{"id": "c-astro"}, {"id": "c-astro"}], "s-3"),
+    ]
+
+    # Act
+    batch = build_phase_two_batch(left_schema, onclause, left_rows)
+
+    # Assert: each distinct id appears exactly once, in first-seen order,
+    # wrapped in the path_params envelope phase-2 expects.
+    assert batch == [
+        {"path_params": {"page_id": "c-astro"}},
+        {"path_params": {"page_id": "c-physics"}},
+    ]
+
+from normlite.sql.dml import merge_inner_join_rows
+
+
+def test_merge_inner_join_emits_one_row_per_left_to_right_match_dropping_unmatched_left_rows():
+    # Arrange: two students, two courses. Student "Galileo" enrolled in
+    # one real course; student "Phantom" points at an id with no matching
+    # right row (dangling FK — must be dropped, inner-join semantics).
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    onclause = students.c.enrolled_in
+
+    left_schema = SchemaInfo.from_table(
+        students,
+        execution_names=[students.c.object_id.name],
+        projected_names=[c.name for c in students.uc],
+    )
+    right_schema = SchemaInfo.from_table(
+        courses,
+        execution_names=[courses.c.object_id.name],
+        projected_names=[c.name for c in courses.uc],
+    )
+
+    # left rows are still in raw phase-1 shape (Relation cell is dict-list)
+    def left_row(name: str, oids: list[str], oid: str) -> tuple:
+        cells = [None] * len(left_schema.columns)
+        cells[left_schema.column_index("name")] = {"title": name}
+        cells[left_schema.column_index("enrolled_in")] = {
+            "relation": [{"id": o} for o in oids]
+        }
+        cells[left_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    # right rows are post-phase-2 retrieve, already in tuple shape that
+    # column_getter("object_id") can index — match what context._staged_result_cursor
+    # yields via _iter_all().
+    def right_row(title: str, oid: str) -> tuple:
+        cells = [None] * len(right_schema.columns)
+        cells[right_schema.column_index("title")] = title
+        cells[right_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    left_rows = [
+        left_row("Galileo Galilei", ["c-astro"],  "s-1"),
+        left_row("Phantom Student", ["c-ghost"],  "s-2"),  # dangling
+    ]
+    right_rows = [
+        right_row("Astronomy", "c-astro"),
+    ]
+
+    # Act
+    merged = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows
+    )
+
+    # Assert: exactly one merged row (Phantom's dangling FK dropped).
+    # The merged tuple is (left projected ⊕ right projected) minus object_id
+    # from each side — matching the existing _project_inner_join shape.
+    assert len(merged) == 1
+    assert {"title": "Galileo Galilei"} in merged[0]
+    assert "Astronomy" in merged[0]
+    
+
+    # Assert: exactly one merged row (Phantom's dangling FK dropped).
+
+    # Assert: exactly one merged row (Phantom's dangling FK dropped).
+    # The merged tuple is (left projected ⊕ right projected) minus object_id
+    # from each side — matching the existing _project_inner_join shape.
+    assert len(merged) == 1
+    assert {"title": "Galileo Galilei"} in merged[0]
+    # The merged tuple is (left projected ⊕ right projected) minus object_id
+    # from each side — matching the existing _project_inner_join shape.
+    assert len(merged) == 1
+    assert {"title": "Galileo Galilei"} in merged[0]
+    assert len(merged) == 1
+    assert {"title": "Galileo Galilei"} in merged[0]
+    assert {"title": "Galileo Galilei"} in merged[0]
+    assert "Astronomy" in merged[0]

--- a/tests/unit/engine/test_join_strategy.py
+++ b/tests/unit/engine/test_join_strategy.py
@@ -149,3 +149,225 @@ def test_merge_inner_join_emits_one_row_per_left_to_right_match_dropping_unmatch
     assert {"title": "Galileo Galilei"} in merged[0]
     assert {"title": "Galileo Galilei"} in merged[0]
     assert "Astronomy" in merged[0]
+
+def test_outer_join_none_fills_dangling_left_row_that_inner_join_drops():
+    # Arrange: the SAME fixture as the inner-join drop test — two students,
+    # one real course. "Galileo" resolves to a real course page; "Phantom"
+    # points at a dangling id with no matching right row (ADR-0002 lax-FK:
+    # a dangling reference is an absent match, never an error).
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    onclause = students.c.enrolled_in
+
+    left_schema = SchemaInfo.from_table(
+        students,
+        execution_names=[students.c.object_id.name],
+        projected_names=[c.name for c in students.uc],
+    )
+    right_schema = SchemaInfo.from_table(
+        courses,
+        execution_names=[courses.c.object_id.name],
+        projected_names=[c.name for c in courses.uc],
+    )
+
+    def left_row(name: str, oids: list[str], oid: str) -> tuple:
+        cells = [None] * len(left_schema.columns)
+        cells[left_schema.column_index("name")] = {"title": name}
+        cells[left_schema.column_index("enrolled_in")] = {
+            "relation": [{"id": o} for o in oids]
+        }
+        cells[left_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    def right_row(title: str, oid: str) -> tuple:
+        cells = [None] * len(right_schema.columns)
+        cells[right_schema.column_index("title")] = title
+        cells[right_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    left_rows = [
+        left_row("Galileo Galilei", ["c-astro"], "s-1"),
+        left_row("Phantom Student", ["c-ghost"], "s-2"),  # dangling FK
+    ]
+    right_rows = [
+        right_row("Astronomy", "c-astro"),
+    ]
+
+    # Act: same strategy, same inputs — only the join kind differs.
+    inner = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+    )
+    outer = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+        isouter=True,
+    )
+
+    # Assert: inner drops the dangling left row; outer keeps it.
+    assert len(inner) == 1
+    assert len(outer) == 2
+
+    # The matched row is identical under both join kinds.
+    matched = [r for r in outer if "Astronomy" in r]
+    assert len(matched) == 1
+    assert {"title": "Galileo Galilei"} in matched[0]
+
+    # The dangling row survives ONLY under outer join, with its LEFT column
+    # intact and its RIGHT column None-filled (not the left side, not dropped).
+    phantom = [r for r in outer if {"title": "Phantom Student"} in r]
+    assert len(phantom) == 1
+    assert "Astronomy" not in phantom[0]
+    assert None in phantom[0]
+
+def test_outer_join_none_fills_left_row_with_empty_relation():
+    # Arrange: one student enrolled in NOTHING (empty relation, zero oids) and
+    # one real course that the student does not reference. An empty relation is
+    # not a dangling FK — there is no id to resolve — but outer-join semantics
+    # must still preserve the left row with the right side None-filled.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    onclause = students.c.enrolled_in
+
+    left_schema = SchemaInfo.from_table(
+        students,
+        execution_names=[students.c.object_id.name],
+        projected_names=[c.name for c in students.uc],
+    )
+    right_schema = SchemaInfo.from_table(
+        courses,
+        execution_names=[courses.c.object_id.name],
+        projected_names=[c.name for c in courses.uc],
+    )
+
+    def left_row(name: str, oids: list[str], oid: str) -> tuple:
+        cells = [None] * len(left_schema.columns)
+        cells[left_schema.column_index("name")] = {"title": name}
+        cells[left_schema.column_index("enrolled_in")] = {
+            "relation": [{"id": o} for o in oids]
+        }
+        cells[left_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    def right_row(title: str, oid: str) -> tuple:
+        cells = [None] * len(right_schema.columns)
+        cells[right_schema.column_index("title")] = title
+        cells[right_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    left_rows = [
+        left_row("Hermit Student", [], "s-1"),  # empty relation: no oids at all
+    ]
+    right_rows = [
+        right_row("Astronomy", "c-astro"),
+    ]
+
+    # Act: same strategy, same inputs — only the join kind differs.
+    inner = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+    )
+    outer = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+        isouter=True,
+    )
+
+    # Assert: inner drops the student with no enrolment.
+    assert inner == []
+
+    # Outer preserves exactly one row: left column intact, right column None.
+    assert len(outer) == 1
+    assert {"title": "Hermit Student"} in outer[0]
+    assert "Astronomy" not in outer[0]
+    assert None in outer[0]
+
+def test_outer_join_does_not_none_fill_a_row_that_already_matched_on_another_oid():
+    # Arrange: ONE student enrolled in two courses by id — one real
+    # ("c-astro" -> "Astronomy") and one dangling ("c-ghost", no right row).
+    # The row already has a match, so outer-join semantics must NOT bolt on a
+    # None-filled row for the unmatched id: None-fill is a whole-row fallback,
+    # fired only when the row matched nothing at all.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    onclause = students.c.enrolled_in
+
+    left_schema = SchemaInfo.from_table(
+        students,
+        execution_names=[students.c.object_id.name],
+        projected_names=[c.name for c in students.uc],
+    )
+    right_schema = SchemaInfo.from_table(
+        courses,
+        execution_names=[courses.c.object_id.name],
+        projected_names=[c.name for c in courses.uc],
+    )
+
+    def left_row(name: str, oids: list[str], oid: str) -> tuple:
+        cells = [None] * len(left_schema.columns)
+        cells[left_schema.column_index("name")] = {"title": name}
+        cells[left_schema.column_index("enrolled_in")] = {
+            "relation": [{"id": o} for o in oids]
+        }
+        cells[left_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    def right_row(title: str, oid: str) -> tuple:
+        cells = [None] * len(right_schema.columns)
+        cells[right_schema.column_index("title")] = title
+        cells[right_schema.column_index("object_id")] = oid
+        return tuple(cells)
+
+    left_rows = [
+        # one real id + one dangling id, in the same relation
+        left_row("Galileo Galilei", ["c-astro", "c-ghost"], "s-1"),
+    ]
+    right_rows = [
+        right_row("Astronomy", "c-astro"),
+    ]
+
+    # Act: a row that matched at least once.
+    inner = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+    )
+    outer = merge_inner_join_rows(
+        left_schema, right_schema, onclause, left_rows, right_rows,
+        isouter=True,
+    )
+
+    # Assert: the dangling id contributes nothing under EITHER join kind —
+    # because the row already matched, outer adds no None-filled row.
+    assert len(inner) == 1
+    assert len(outer) == 1
+    assert inner == outer
+
+    # The single surviving row is the real match, with no None-fill anywhere.
+    assert {"title": "Galileo Galilei"} in outer[0]
+    assert "Astronomy" in outer[0]
+    assert None not in outer[0]

--- a/tests/unit/notiondbapi/test_dbapi2.py
+++ b/tests/unit/notiondbapi/test_dbapi2.py
@@ -7,7 +7,7 @@ from faker import Faker
 
 from normlite.notion_sdk.client import InMemoryNotionClient
 from normlite.notion_sdk.getters import rich_text_to_plain_text
-from normlite.notiondbapi.dbapi2 import Cursor, ProgrammingError
+from normlite.notiondbapi.dbapi2 import Connection, Cursor, ProgrammingError
 
 @pytest.fixture
 def client() -> InMemoryNotionClient:
@@ -226,7 +226,7 @@ get_name = itemgetter(4)
 #----------------------------------------------------------------
 
 def test_description_none_if_no_execute(client: InMemoryNotionClient):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
 
     assert cursor.description is None
 
@@ -234,7 +234,7 @@ def test_description_none_if_no_rows(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=10)
     execute_query_returns_no_rows(cursor, row_description, database_id)
 
@@ -244,7 +244,7 @@ def test_description_none_on_closed_cursor(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=10)
     execute_query_returns_all_rows(cursor, row_description, database_id)
     cursor.close()
@@ -259,7 +259,7 @@ def test_fetchone_returns_none_if_no_rows_found(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=10)
     cursor._inject_description(row_description)
     execute_query_returns_no_rows(cursor, row_description, database_id)
@@ -271,7 +271,7 @@ def test_fetchone_returns_first_row_found(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=10)
     cursor._inject_description(row_description)
     execute_query_returns_all_rows(cursor, row_description, database_id)
@@ -287,7 +287,7 @@ def test_fetchone_consumes_cursor(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=3)
     cursor._inject_description(row_description)
     execute_query_returns_all_rows(cursor, row_description, database_id)
@@ -316,7 +316,7 @@ def test_fetchone_raises_on_closed_cursor(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=3)
     cursor._inject_description(row_description)
     execute_query_returns_all_rows(cursor, row_description, database_id)
@@ -328,7 +328,7 @@ def test_fetchone_raises_on_closed_cursor(
 def test_fetchone_raises_if_no_execute(
     client: InMemoryNotionClient, 
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     with pytest.raises(ProgrammingError):
         _ = cursor.fetchone()
 
@@ -340,7 +340,7 @@ def test_fetchall_returns_all_rows_found(
     client: InMemoryNotionClient, 
     row_description: tuple[tuple, ...],
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, pages = generate_pages(client, n=100)
     cursor._inject_description(row_description)
     execute_query_returns_all_rows(cursor, row_description, database_id)
@@ -362,14 +362,14 @@ def test_fetchall_returns_all_rows_found(
 def test_fetchall_raises_if_no_execute(
     client: InMemoryNotionClient, 
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     with pytest.raises(ProgrammingError):
         _ = cursor.fetchall()
 
 def test_fetchall_raises_on_closed_cursor(
     client: InMemoryNotionClient, 
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     cursor.close()
     with pytest.raises(ProgrammingError):
         _ = cursor.fetchall()
@@ -383,7 +383,7 @@ def test_fetch_many_returns_arrasize_multiples_of_rows(
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...]
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, inserted_rows = generate_pages(client, 16)
     execute_query_returns_all_rows(cursor, row_description, database_id)
     cursor.arraysize = 8
@@ -399,14 +399,14 @@ def test_fetch_many_returns_arrasize_multiples_of_rows(
 def test_fetchmany_raises_if_no_execute(
     client: InMemoryNotionClient, 
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     with pytest.raises(ProgrammingError):
         _ = cursor.fetchmany()
 
 def test_fetchmany_raises_on_closed_cursor(
     client: InMemoryNotionClient, 
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     cursor.close()
     with pytest.raises(ProgrammingError):
         _ = cursor.fetchmany()
@@ -416,14 +416,14 @@ def test_fetchmany_raises_on_closed_cursor(
 #----------------------------------------------------------------
 
 def test_rowcount_returns_minus_one_if_no_execute(client):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     assert cursor.rowcount == -1
 
 def test_rowcount_returns_zero_if_no_rows_found(        
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...]
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, inserted_rows = generate_pages(client, 1000)
     execute_query_returns_no_rows(cursor, row_description, database_id)
     
@@ -434,7 +434,7 @@ def test_rowcount_returns_count_of_all_rows_found(
     row_description: tuple[tuple, ...]
 ):
     n_pages = 100
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n_pages)
     execute_query_returns_all_rows(cursor, row_description, database_id)
 
@@ -449,7 +449,7 @@ def test_lastrowid_returns_last_inserted_id(
     row_description: tuple[tuple, ...]
 ):
     n_pages = 100
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, inserted_rows = generate_pages(client, n_pages)
     execute_query_returns_all_rows(cursor, row_description, database_id)
     # check generate_pages() for how inserted rows are returned
@@ -460,7 +460,7 @@ def test_lastrowid_returns_last_inserted_id(
 def test_lastrowid_returns_none_if_table_metadata_retrieved(
     client: InMemoryNotionClient,
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, inserted_rows = generate_pages(client, n=10)
     # retrieve "students" database
     cursor.execute(
@@ -476,7 +476,7 @@ def test_lastrowid_returns_none_if_no_rows_modified(
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...]
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, inserted_rows = generate_pages(client, n=10)
     execute_query_returns_no_rows(cursor, row_description, database_id)
     assert len(cursor.fetchall()) == 0
@@ -508,7 +508,7 @@ def test_executemany_executes_all_operations(
     """
 
     # pre-fill the client
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=10)
     
     # get all pages belonging to the database
@@ -540,7 +540,7 @@ def test_executemany_produces_multiple_result_sets(
     """
 
     # pre-fill the client
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=10)
     
     pages = return_all_pages_in_database(client, database_id)
@@ -562,6 +562,31 @@ def test_executemany_produces_multiple_result_sets(
     assert len(rows) == 1
 
 
+def test_executemany_default_errorhandler_raises_translated_notion_error(
+    client: InMemoryNotionClient,
+):
+    """A NotionError during executemany must route through the cursor's default
+    errorhandler (inherited from the connection) and surface as the translated
+    DBAPI error.
+
+    Regression for the ``Cursor(connection)`` refactor: the cursor never
+    initialised ``_errorhandler`` (the getter would raise AttributeError) and
+    the getter read the connection's misspelled ``error_handler`` attribute.
+    With no per-cursor handler set, ``cursor.errorhandler`` must fall back to
+    ``connection.errorhandler`` (the default), which re-raises ``errorvalue``.
+    """
+    # no per-cursor errorhandler override -> must use the connection's default
+    cursor = Cursor(Connection(client))
+
+    # retrieving a non-existent page makes the client raise a
+    # NotionError(code="object_not_found"), translated to ProgrammingError
+    with pytest.raises(ProgrammingError):
+        cursor.executemany(
+            operation={"endpoint": "pages", "request": "retrieve"},
+            parameters=[{"path_params": {"page_id": "does-not-exist"}}],
+        )
+
+
 def test_next_moves_to_next_result_set(
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...]
@@ -570,7 +595,7 @@ def test_next_moves_to_next_result_set(
     next() should move the cursor to the next result set.
     """
 
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=10)
     pages = return_all_pages_in_database(client, database_id)
     params = [build_trash_operation(p["id"]) for p in pages]
@@ -602,7 +627,7 @@ def test_next_allows_iterating_all_result_sets(
     All result sets should be reachable through next().
     """
 
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=100)
     pages = return_all_pages_in_database(client, database_id)
     params = [build_trash_operation(p["id"]) for p in pages]
@@ -635,7 +660,7 @@ def test_next_on_last_result_set_exhausts_results(
     Calling next() after the last result set should exhaust the cursor.
     """
 
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=100)
     pages = return_all_pages_in_database(client, database_id)
     params = [build_trash_operation(p["id"]) for p in pages]
@@ -661,7 +686,7 @@ def test_rowcount_returns_sum_of_resultsets(
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...]
 ):
-    cursor = Cursor(client)
+    cursor = Cursor(Connection(client))
     database_id, _ = generate_pages(client, n=100)
     pages = return_all_pages_in_database(client, database_id)
     params = [build_trash_operation(p["id"]) for p in pages]

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -7,7 +7,7 @@ from normlite import Relation, ForeignKey
 from normlite.exceptions import ArgumentError, CompileError
 from normlite.sql.compiler import NotionCompiler
 from normlite.sql.dml import Join, select
-from normlite.sql.elements import ColumnElement
+from normlite.sql.elements import ColumnElement, OrderByExpression
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import String
 
@@ -244,4 +244,53 @@ def test_where_expression_with_no_source_table_raises_compile_error(students: Ta
         __visit_name__ = "unknown_expr"
     stmt = select(students).where(_UnknownExpr())
     with pytest.raises(CompileError, match=r"route WHERE expression"):
+        stmt.compile(NotionCompiler())
+
+def test_right_side_order_by_stays_out_of_phase_one_query_payload(
+    students: Table, courses: Table
+):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    # An ORDER BY on the RIGHT table (courses). Notion's databases.query can only
+    # sort by the left table's properties, so this sort must NOT ride along in the
+    # phase-1 query payload — it has to be applied client-side after the join.
+    stmt = (
+        select(students, courses)
+        .join(students.c.enrolled_in)
+        .order_by(courses.c.title.asc())
+    )
+
+    asdict = stmt.compile(NotionCompiler()).as_dict()
+
+    # phase-1 payload must carry no sort built from a right-table column
+    assert "sorts" not in asdict["payload"]
+
+def test_mixed_left_right_order_by_stays_out_of_phase_one_regardless_of_order(
+    students: Table, courses: Table
+):
+    # Compound ORDER BY touching BOTH sides; a right-table column is involved, so the
+    # whole sort must stay out of phase-1, and routing must NOT depend on clause order.
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    left_then_right = (
+        select(students, courses).join(students.c.enrolled_in)
+        .order_by(students.c.name.asc(), courses.c.title.asc())
+        .compile(NotionCompiler()).as_dict()
+    )
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    right_then_left = (
+        select(students, courses).join(students.c.enrolled_in)
+        .order_by(courses.c.title.asc(), students.c.name.asc())
+        .compile(NotionCompiler()).as_dict()
+    )
+    assert "sorts" not in left_then_right["payload"]
+    assert "sorts" not in right_then_left["payload"]
+
+def test_order_by_expression_with_no_source_table_raises_compile_error(students: Table):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    class _UnknownExpr(ColumnElement):
+        __visit_name__ = "unknown_expr"
+    # An ORDER BY clause whose sort key is an unattributable node: the router can
+    # reach no source table, so it must fail loudly rather than drop the sort.
+    stmt = select(students).order_by(OrderByExpression(_UnknownExpr(), "asc"))
+    with pytest.raises(CompileError, match=r"route ORDER BY expression"):
         stmt.compile(NotionCompiler())

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -104,6 +104,49 @@ def test_select_with_join_emits_join_metadata_in_compiled_dict(
     assert j['onclause'] == 'enrolled_in'
     assert j['isouter'] is False
 
+def test_join_target_table_auto_resolves_single_fk_to_same_compiled_output(
+    students: Table, courses: Table
+):
+    # Seed object_id so phase-1 compiles deterministically
+    # (mirrors test_select_with_join_emits_join_metadata_in_compiled_dict).
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    # explicit-column form (the canonical slice-1 contract)
+    explicit = (
+        select(students, courses)
+        .join(students.c.enrolled_in)
+        .compile(NotionCompiler())
+        .as_dict()
+    )
+
+    # sugar form: hand .join() the target table instead of the column
+    sugar = (
+        select(students, courses)
+        .join(courses)
+        .compile(NotionCompiler())
+        .as_dict()
+    )
+
+    # the sugar must rewrite to the same join and compile identically
+    assert sugar == explicit
+
+def test_join_unreferenced_table_raises_argument_error_not_index_error(
+    students: Table,
+):
+    # A table the left table has no foreign key to, built under a SEPARATE
+    # MetaData so its name isn't even present in students' metadata. The sugar
+    # form must reject it with a clear ArgumentError — not crash with IndexError
+    # from indexing an empty relation-column list.
+    other_meta = MetaData()
+    workshops = Table(
+        "workshops",
+        other_meta,
+        Column("title", String(is_title=True)),
+    )
+
+    with pytest.raises(ArgumentError, match=r"not a referenced table"):
+        select(students).join(workshops)
+
 def test_join_with_non_relation_column_raises_argument_error(
     students: Table, courses: Table
 ):
@@ -139,3 +182,18 @@ def test_join_explicit_onclause_with_non_relation_left_raises_argument_error(
 
     with pytest.raises(ArgumentError, match=r"Relation"):
         select(students, courses).join(bad_expr)
+
+def test_two_relations_to_same_target_table_raise_naming_both_columns(
+    metadata: MetaData, courses: Table
+):
+    # Notion's data model forbids two relation properties pointing at the same
+    # database. When a schema author declares two such columns, the error must
+    # name BOTH colliding columns — otherwise they can't tell which to fix.
+    with pytest.raises(ArgumentError, match=r"already has a relation.*courses"):
+        Table(
+            "enrollments",
+            metadata,
+            Column("title", String(is_title=True)),
+            Column("primary_course", Relation(), ForeignKey("courses.object_id")),
+            Column("backup_course", Relation(), ForeignKey("courses.object_id")),
+        )

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -4,9 +4,10 @@ import uuid
 import pytest
 
 from normlite import Relation, ForeignKey
-from normlite.exceptions import ArgumentError
+from normlite.exceptions import ArgumentError, CompileError
 from normlite.sql.compiler import NotionCompiler
 from normlite.sql.dml import Join, select
+from normlite.sql.elements import ColumnElement
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import String
 
@@ -197,3 +198,50 @@ def test_two_relations_to_same_target_table_raise_naming_both_columns(
             Column("primary_course", Relation(), ForeignKey("courses.object_id")),
             Column("backup_course", Relation(), ForeignKey("courses.object_id")),
         )
+
+def test_right_side_where_filter_stays_out_of_phase_one_query_payload(
+    students: Table, courses: Table
+):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    # A filter on the RIGHT table (courses). Notion's databases.query can only
+    # filter the left table's properties, so this condition must NOT ride along
+    # in the phase-1 query payload — it has to be answered client-side instead.
+    stmt = (
+        select(students, courses)
+        .join(students.c.enrolled_in)
+        .where(courses.c.title == "Astronomy")
+    )
+
+    asdict = stmt.compile(NotionCompiler()).as_dict()
+
+    # phase-1 payload must carry no filter built from a right-table column
+    assert "filter" not in asdict["payload"]
+
+def test_mixed_left_right_where_compound_stays_out_of_phase_one_regardless_of_order(
+    students: Table, courses: Table
+):
+    # Compound WHERE touching BOTH sides; a right-table column is involved, so the
+    # whole compound must stay out of phase-1, and routing must NOT depend on order.
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    left_then_right = (
+        select(students, courses).join(students.c.enrolled_in)
+        .where(students.c.name == "Galileo").where(courses.c.title == "Astronomy")
+        .compile(NotionCompiler()).as_dict()
+    )
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    right_then_left = (
+        select(students, courses).join(students.c.enrolled_in)
+        .where(courses.c.title == "Astronomy").where(students.c.name == "Galileo")
+        .compile(NotionCompiler()).as_dict()
+    )
+    assert "filter" not in left_then_right["payload"]
+    assert "filter" not in right_then_left["payload"]
+
+def test_where_expression_with_no_source_table_raises_compile_error(students: Table):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+    class _UnknownExpr(ColumnElement):
+        __visit_name__ = "unknown_expr"
+    stmt = select(students).where(_UnknownExpr())
+    with pytest.raises(CompileError, match=r"route WHERE expression"):
+        stmt.compile(NotionCompiler())

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -1,3 +1,4 @@
+import pdb
 import uuid
 
 import pytest
@@ -85,6 +86,9 @@ def test_select_with_join_emits_join_metadata_in_compiled_dict(
     compiled = stmt.compile(nc)
     asdict = compiled.as_dict()
 
+    # bug: this shall not fail
+    assert nc._compiler_state.stmt is not None
+
     # phase-1 portion: same shape as a plain select(students) would produce
     assert asdict['operation'] == {'endpoint': 'databases', 'request': 'query'}
     assert asdict['payload']['page_size'] == 100
@@ -99,18 +103,6 @@ def test_select_with_join_emits_join_metadata_in_compiled_dict(
     assert j['right'] == 'courses'
     assert j['onclause'] == 'enrolled_in'
     assert j['isouter'] is False
-
-def test_execute_with_join_raises_notimplementederror_until_slice_2(
-    students: Table, courses: Table
-):
-    # plain select must remain executable (no-op setup)
-    plain = select(students)
-    plain._setup_execution(None)  # no raise
-
-    # select with a join must fail loudly with a pointer to slice 2 / #304
-    joined = select(students, courses).join(students.c.enrolled_in)
-    with pytest.raises(NotImplementedError, match=r"slice 2|#304"):
-        joined._setup_execution(None)
 
 def test_join_with_non_relation_column_raises_argument_error(
     students: Table, courses: Table

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -1,0 +1,149 @@
+import uuid
+
+import pytest
+
+from normlite import Relation, ForeignKey
+from normlite.exceptions import ArgumentError
+from normlite.sql.compiler import NotionCompiler
+from normlite.sql.dml import Join, select
+from normlite.sql.schema import Column, MetaData, Table
+from normlite.sql.type_api import String
+
+
+@pytest.fixture
+def metadata() -> MetaData:
+    return MetaData()
+
+
+@pytest.fixture
+def courses(metadata: MetaData) -> Table:
+    return Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+
+
+@pytest.fixture
+def students(metadata: MetaData, courses: Table) -> Table:
+    return Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+
+
+def test_join_node_carries_left_right_onclause_and_defaults_to_inner(
+    students: Table, courses: Table
+):
+    join = Join(students, courses, students.c.enrolled_in)
+
+    assert join.left is students
+    assert join.right is courses
+    assert join.onclause is students.c.enrolled_in
+    assert join.isouter is False
+    assert join.__visit_name__ == "join"
+
+def test_select_init_accepts_two_tables_without_raising(
+    students: Table, courses: Table
+):
+    stmt = select(students, courses)
+
+    # construction succeeds (no ArgumentError) and the first table
+    # remains the "left" driver, reachable through the existing accessor
+    assert stmt._table is students
+
+def test_join_is_generative_and_accumulates_join_node(
+    students: Table, courses: Table
+):
+    base = select(students, courses)
+
+    joined = base.join(students.c.enrolled_in)
+
+    # generative: returns a new Select, the receiver is not mutated
+    assert joined is not base
+    assert len(base._joins) == 0
+    assert len(joined._joins) == 1
+
+    # the accumulated Join is wired against the entity list + onclause
+    j = joined._joins[0]
+    assert isinstance(j, Join)
+    assert j.left is students
+    assert j.right is courses
+    assert j.onclause is students.c.enrolled_in
+    assert j.isouter is False
+
+def test_select_with_join_emits_join_metadata_in_compiled_dict(
+    students: Table, courses: Table
+):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    stmt = select(students, courses).join(students.c.enrolled_in)
+
+    nc = NotionCompiler()
+    compiled = stmt.compile(nc)
+    asdict = compiled.as_dict()
+
+    # phase-1 portion: same shape as a plain select(students) would produce
+    assert asdict['operation'] == {'endpoint': 'databases', 'request': 'query'}
+    assert asdict['payload']['page_size'] == 100
+    assert asdict['payload']['in_trash'] is False
+
+    # new: a top-level 'joins' block carries one join entry
+    assert 'joins' in asdict
+    assert len(asdict['joins']) == 1
+
+    j = asdict['joins'][0]
+    assert j['left'] == 'students'
+    assert j['right'] == 'courses'
+    assert j['onclause'] == 'enrolled_in'
+    assert j['isouter'] is False
+
+def test_execute_with_join_raises_notimplementederror_until_slice_2(
+    students: Table, courses: Table
+):
+    # plain select must remain executable (no-op setup)
+    plain = select(students)
+    plain._setup_execution(None)  # no raise
+
+    # select with a join must fail loudly with a pointer to slice 2 / #304
+    joined = select(students, courses).join(students.c.enrolled_in)
+    with pytest.raises(NotImplementedError, match=r"slice 2|#304"):
+        joined._setup_execution(None)
+
+def test_join_with_non_relation_column_raises_argument_error(
+    students: Table, courses: Table
+):
+    # students.c.name is a String column, not a Relation — illegal as an onclause
+    with pytest.raises(ArgumentError, match=r"Relation"):
+        select(students, courses).join(students.c.name)
+
+def test_join_onclause_from_outside_left_table_raises_argument_error(
+    metadata: MetaData, students: Table, courses: Table
+):
+    # A third table with its own Relation column. The column is well-formed
+    # (Relation type + ForeignKey), but its parent is `instructors`, not the
+    # left table `students` of the select-join under test.
+    instructors = Table(
+        "instructors",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("teaches", Relation(), ForeignKey("courses.object_id")),
+    )
+
+    with pytest.raises(ArgumentError, match=r"students|left"):
+        select(students, courses).join(instructors.c.teaches)
+
+def test_diagnostic_parent_identity(students: Table):
+    assert students.c.enrolled_in.parent is students
+
+def test_join_explicit_onclause_with_non_relation_left_raises_argument_error(
+    students: Table, courses: Table
+):
+    # A BinaryExpression whose left side is students.c.name (a String, not a Relation).
+    # The join machinery has nothing to traverse from a String column.
+    bad_expr = students.c.name == "Galileo"
+
+    with pytest.raises(ArgumentError, match=r"Relation"):
+        select(students, courses).join(bad_expr)


### PR DESCRIPTION
Implements the `Select.join()` feature (PRD #302) incrementally via teaching-TDD slices.

## Slices landed on this branch
- **Slices 1, 3** (#303, #305) — `Join` AST node + `Select.join()` with compile-time
  validation; inner-join cross-product lifted into `merge_inner_join_rows`. (`c8671c7`, `f771d43`)
- **Slice 4** (#306) — `.join(table)` FK auto-detection: resolve the left table's single
  relation column whose `ForeignKey` references the passed table; one-relation-per-target
  invariant enforced in `Table.add_constraint`; `ArgumentError` (not `IndexError`) for an
  unreferenced target. (`1db4b62`)
- **Slice 5** (#307) — source-table routing for WHERE and ORDER BY: a clause touching only
  the left table rides into the phase-1 `databases.query` payload (`filter` / `sorts`);
  anything touching the right table is held out of phase-1 (answered client-side). Shared
  `_get_expression_parent_tables` fold, routed on `parent_tables == {select._table}`;
  `CompileError` on an unattributable expression. (`88a0b5f`, `576f62f`)
- **Slice 6** (#308) — LEFT OUTER JOIN + dangling-FK `None`-fill. `.outerjoin(...)` is sugar
  for `Join(..., isouter=True)`; inner vs outer diverge at a **single** `isouter`-gated site
  in `merge_inner_join_rows` (None-fill the right on zero matches). A right-side `WHERE` is
  applied **post-merge**: phantom (`None`-filled) rows fail every right-side predicate by
  **SQL NULL semantics** — dropped via a structural all-`None` check, not by fabricating
  per-type Notion-empty values. Benign 404 (`object_not_found`) on phase-2 `pages.retrieve`
  is silenced (lax-FK); any other retrieve error propagates via `_join_errorhandler`.
  (`6872e75`, `77680c2`)

## Design records
- **ADR-0004** (`docs/adr/0004-expression-hierarchy-modifier-vs-column.md`) — `ModifierExpression`
  stays a `ClauseElement` sibling of `ColumnElement`; `ColumnElement` intentionally has no
  `parent`. Surfaced by the shared routing fold.
- **ADR-0005** (`docs/adr/0005-outer-join-phantom-null-semantics.md`) — an outer-join phantom
  obeys **SQL NULL** semantics, not Notion empty-property semantics. Notion has no NULL, and
  some types have no honest empty (checkbox is never empty; an empty `number` `TypeError`s in
  comparisons), so the phantom is dropped structurally rather than reconstructed.

## Deferred / follow-ups (captured, not blocking this PR)
- **#311** — per-clause splitting of compound WHERE/ORDER BY (push the pushable left part to
  phase-1). Connective-aware for WHERE (safe under AND, forbidden under OR); the current
  slice-5 behavior is conservative all-or-nothing.
- **Anti-join inexpressible** — `LEFT JOIN ... WHERE right IS NULL` can't be expressed (no
  `IS NULL` in Notion; `is_empty ≠ IS NULL`; any right-side `WHERE` drops the phantom). Only a
  bare `outerjoin()` keeps unmatched left rows.
- **Unreachable empty-title KEEP-side** — `String.bind_processor` never emits `{title: []}`,
  so a present-but-empty title can't be constructed; `title=None` yields a `None` cell the
  `all(None)` heuristic would mislabel as a phantom (first crack in the `None ⟺ phantom`
  invariant).
- **`_Filter` empty-comparison hardening** (ADR-0005 Alt A) — an empty `number` compared in
  the fake's `databases.query` `TypeError`s; a separate slice with its own red test.

## Still to come (this PR will grow)
- **Slice 7** (#309) — projection narrowing. **Slice 8** (#310).

## Tests
`tests/unit/{engine,sql,notiondbapi}` — **539 passed / 3 skipped** at `77680c2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)