### PR TITLE
docs(adr): ADR-0009 result-schema provenance + resolve ADR-0006 collision limitation (#319)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,15 @@ subclass that maps to the Notion property type and owns the bind/filter value pr
 A column explicitly declared by the user in `Table(...)`. Distinct from **system columns** (e.g.
 `object_id`, `_no_id`) which are injected by normlite and carry Notion metadata.
 
+### Projected column name (collision qualification)
+A `select(...)` projection preserves the order in which columns are listed. When the projection
+spans two joined tables and a **column name is shared** by both (e.g. both `students` and
+`courses` declare `title`), each colliding column surfaces **fully qualified** as
+`table.column` (`students.title`, `courses.title`) in `keys()` / `mappings()`; non-colliding
+names stay **bare**. Selecting the **same column twice** (`select(students.c.title,
+students.c.title)`) is an **error**, while the same bare name from two different tables
+(`select(students.c.title, courses.c.title)`) is allowed and qualified as above.
+
 ### DML Statement
 One of `Insert`, `Delete`, `Update`, `Select` — the four DML constructs. Each produces a compiled
 payload and follows the two-phase or single-phase execution pipeline below.

--- a/docs/adr/0006-join-result-row-shape.md
+++ b/docs/adr/0006-join-result-row-shape.md
@@ -78,14 +78,18 @@ the wire, and makes `filter_properties` dead weight.
   qualified keys on collision with no shadowing.
 - The merged-column order is deterministic (projection order, left before right), so
   repeated runs and `mappings()` lookups are stable.
-- **Known limitation — right-side `WHERE` on a colliding column is unsupported in v1.** The
-  post-merge right-side filter looks its getters up by the bare right-table column name,
-  while a colliding right column is keyed fully-qualified in the joined schema — so a
-  `WHERE` on that exact column is silently ignored, or (if it is the only projected right
-  column) drops every row via the all-None phantom guard. Workaround: qualify or rename.
-  A real fix must look the getter up by the joined (qualified) name and needs its own slice
-  with a red test. See issue #309 / #310 discussion. The all-None phantom-drop rule
-  ([ADR-0005](./0005-outer-join-phantom-null-semantics.md)) is unaffected.
+- **Right-side `WHERE` on a colliding column — RESOLVED by
+  [ADR-0009](./0009-result-schema-provenance.md).** The post-merge right-side filter looked
+  its getters up by the bare right-table column name, while a colliding right column is keyed
+  fully-qualified in the joined schema. The original failure was **two** distinct outcomes
+  (the prior text saying "silently ignored" was inaccurate): if the colliding column was the
+  **only** projected right column, the all-None phantom guard silently dropped every row; if
+  another non-colliding right column was present, `_Filter` **raised**
+  `ValueError: Property '<name>' not found on page`. ADR-0009 fixes both by giving
+  `ResultColumn` provenance and selecting the right-side getters by **table identity**, not
+  name (keying the synthetic page by the bare name the filter references). The all-None
+  phantom-drop rule ([ADR-0005](./0005-outer-join-phantom-null-semantics.md)) is preserved.
+  See issue #309 / #310 discussion.
 - Filtering on a **non-projected** right column is likewise unreconstructable from the merged
   tuple and is out of scope here (it needs evaluation against the raw phase-2 page).
 - `SchemaInfo.from_join` does not yet compose `from_table`; that consolidation is deferred.

--- a/docs/adr/0009-result-schema-provenance.md
+++ b/docs/adr/0009-result-schema-provenance.md
@@ -1,0 +1,113 @@
+# ADR-0009: Result-schema provenance & explicit colliding projections
+
+**Status:** Accepted
+**Date:** 2026-06-14
+
+---
+
+## Context
+
+[ADR-0006](./0006-join-result-row-shape.md) settled the join result row-shape and, on a
+left/right column-name collision, qualified the colliding result columns
+(`students.title`, `courses.title`) while leaving non-colliding names bare. It left one
+boundary open, recorded as a known limitation: a **right-side `WHERE` on a colliding
+column** is broken. Two things forced this ADR:
+
+1. **The collision was barely reachable, and the fix touches a shared type.** An explicit
+   duplicate-name projection — `select(students.c.title, courses.c.title)` — could not even
+   be constructed: `Select._projection` was a `ColumnCollection`, which rejects duplicate
+   *names* with `DuplicateColumnError`. The collision was reachable **only** through
+   full-table expansion `select(students, courses)` (which bypasses the collection,
+   `dml.py:611`). We want explicit colliding projections to be a first-class, supported
+   query — which means the projection can no longer be name-keyed.
+
+2. **The right-side filter, and two other sites, identified columns by name.** Once a
+   colliding right column is keyed fully-qualified in the merged schema (`courses.title`)
+   but the compiled Notion filter references the **bare** name (`visit_binary_expression`
+   emits `column.name` = `title`), every name-based lookup in the join pipeline mis-fires
+   under collision. The post-merge right-side filter (`JoinExecution._right_side_passes`)
+   selected its getters with `c.name in right.uc` — false for `courses.title` — and keyed
+   its synthetic page by the qualified name, so the bare-named filter could not find it.
+   This produced **two** wrong outcomes (verified empirically): if the colliding column was
+   the *only* projected right column the all-None phantom guard silently dropped **every**
+   row; if another non-colliding right column was present, `_Filter` raised
+   `ValueError: Property 'title' not found on page`. (ADR-0006's text called both "silently
+   ignored"; only the first is silent — corrected there.)
+
+The root cause across all of these is the same: the result schema knew a column's *name* but
+not its *origin*, so it relied on name-matching, which is exactly what collisions break.
+
+## Decision
+
+**Give result columns explicit provenance and select by identity, not by name; and make a
+two-table projection a plain ordered sequence so colliding columns can be projected
+explicitly.**
+
+- **Provenance on `ResultColumn` (always set).** Every `ResultColumn` carries two extra
+  fields — `table: Table` (the owning table) and `bare_name: str` (the original,
+  unqualified name) — populated by **both** `SchemaInfo.from_table` and
+  `SchemaInfo.from_join`. They are `compare=False, repr=False`, so `ResultColumn` equality
+  and the DBAPI `description` (`as_sequence()`) are unchanged. The public `name` field stays
+  the merged key (qualified on collision). Provenance is an **invariant**, never `None`.
+
+- **Selection by identity.** The right-side filter selects its columns with
+  `col.table is self._join.right` instead of `col.name in right.uc`. The getter is taken at
+  the merged (qualified) name via the existing index; the synthetic page is keyed by
+  `col.bare_name` — which matches the bare name the compiled filter references. The
+  synthetic page is right-only, so bare names are unambiguous *within it*.
+
+- **`Select._projection` becomes `tuple[Column, ...]`.** All three construction paths
+  (single table, two-table full expansion, explicit column list) normalize to a tuple, in
+  projection order. Dropping `ColumnCollection` removes the name-dedup that rejected
+  duplicate-name projections, so explicit `select(a.c.x, b.c.x)` is now constructable and
+  qualified by `from_join`.
+
+- **Same column twice is a hard error, in `Select.__init__`.** Removing the collection's
+  dedup would also let the *same* `(table, name)` be projected twice — which `from_join`
+  would qualify to two identical keys and silently collapse. A guard alongside the existing
+  belongs-to-table safeguard rejects a repeated `(parent, name)` with `ArgumentError`, while
+  allowing the same bare name from two different tables.
+
+- **The compiler's left-fetch filter switches to identity.** `visit_select` built the
+  phase-1 left fetch list with `col.name in select._table.c` (`compiler.py:636`); under an
+  explicit collision the right column's name (`title`) is also present in the left table, so
+  it leaked into the left query. Changed to `col.parent is select._table`, matching
+  `_project_join_row` (`dml.py:1194`).
+
+## Alternatives Considered
+
+**A. Reconstruct `from_join`'s qualification rule inline at the getter-selection site.**
+Compute `f"{right.name}.{name}"` when the bare name also appears in `left.uc`, look the
+getter up by that, key the page bare. Rejected: it duplicates the qualification rule in two
+places that must stay in lock-step, leaving the same name-matching fragility one refactor
+away from breaking again. Provenance kills the whole class rather than patching the one site.
+
+**B. Make the compiled Notion filter emit qualified property names on collision.** Rejected:
+it would push join-projection awareness into `visit_binary_expression`, which has no join
+context, to fix a problem the synthetic page can reconcile locally (right-only page → bare
+names are unambiguous).
+
+**C. Keep provenance optional / join-only (`Optional[Table] = None`, set only by
+`from_join`).** Rejected: a sometimes-`None` field reintroduces the implicit contract the
+provenance work exists to remove. `from_table` populating it (single owning table,
+`bare_name = name`) is trivial, including for system columns, which carry harmless
+provenance no reader consults.
+
+## Consequences
+
+- **Resolves the ADR-0006 right-side-`WHERE`-on-collision limitation.** Both sub-cases
+  (silent over-drop; `ValueError`) are fixed; the all-None phantom-drop rule
+  ([ADR-0005](./0005-outer-join-phantom-null-semantics.md)) is preserved — a genuine match's
+  right slice is now non-`None`, an outer phantom is still all-`None`.
+- **New supported query shape.** `select(students.c.title, courses.c.title)` is valid and
+  yields qualified result keys; this is a user-visible API addition (see CONTEXT.md,
+  "Projected column name (collision qualification)").
+- **Out of scope (known boundary).** A two-table projection with **no** `.join()`
+  (`select(students.c.name, courses.c.title)` without a join clause) is pre-existing,
+  unchanged behavior — identical for colliding and non-colliding names — and is **not**
+  addressed here. No guard requiring `.join()` is added.
+- **Implementation lands TDD-first** with a RED test for the silent over-drop (genuine match
+  survives), the `ValueError` sub-case, a discriminating predicate (a row that *should* drop
+  still drops), and an outer-join phantom-drop regression under collision.
+- **Compiler and cursor contracts otherwise untouched.** `as_sequence()` (the DBAPI
+  `description`) and `ResultColumn` equality are unchanged; provenance is internal.


### PR DESCRIPTION
Records the agreed design for the right-side `WHERE`-on-a-colliding-column fix and resolves the
ADR-0006 known limitation. **Docs only — no production code** (that lands TDD-first under #319).

## Changes
- **New** `docs/adr/0009-result-schema-provenance.md` — provenance on `ResultColumn`
  (`table` + `bare_name`, always-set), identity-based right-side getter selection,
  `Select._projection` → `tuple[Column]` enabling explicit `select(a.c.x, b.c.x)`, the
  same-`(parent,name)` duplicate guard, and the compiler fetch-columns identity fix. Includes
  alternatives (inline-rule / filter-FQ / optional-provenance) and ADR-0005 preservation.
- **Amend** `docs/adr/0006-join-result-row-shape.md` — limitation bullet flipped to resolved;
  corrects the stale "silently ignored" wording (the multi-right-col sub-case raises
  `ValueError`, only the single-col sub-case is silent).
- **Amend** `CONTEXT.md` — new term "Projected column name (collision qualification)".

## Two facts corrected vs. prior docs (verified empirically this session)
1. The collision was reachable **only** via full-table expansion `select(students, courses)`;
   `select(a.c.title, b.c.title)` was unconstructable (`DuplicateColumnError`). This design
   deliberately enables the explicit form.
2. The failure mode is **not uniformly silent** — silent over-drop only when the colliding col
   is the sole right column; otherwise `_Filter` raises `ValueError`.

Implementation tracked in #319.

Refs #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)