### PR TITLE
feat(sql): per-clause WHERE/ORDER BY routing across join sides (#311)

### DIFF
--- a/src/normlite/engine/context.py
+++ b/src/normlite/engine/context.py
@@ -248,6 +248,12 @@ class ExecutionContext:
     .. versionadded:: 0.11.0
     """
 
+    join_right_sorts: Optional[list[dict]]
+    """The optional sort criteria for the ORDER BY with right column expressions
+    
+    .. versionadded:: 0.11.0
+    """
+
     execution_style: ExecutionStyle
     """The style of DBAPI cursor method that will be used to execute a statement.
 
@@ -332,6 +338,7 @@ class ExecutionContext:
         self.query_params = None
         self.payload = None
         self.join_right_filter = None
+        self.join_right_sorts = None
         self._result = None
         self._rowcount = None
         self._returned_primary_keys_rows = None
@@ -516,6 +523,9 @@ class ExecutionContext:
         if 'join_right_filter' in self.compiled_dict:
             template = self.compiled_dict['join_right_filter']
             self.join_right_filter = self._bind_params(template, resolved_params[0])
+
+        if 'join_right_sorts' in self.compiled_dict:
+            self.join_right_sorts = self.compiled_dict.get("join_right_sorts")
 
         if self.invoked_stmt.is_update:
             self.resolved_params = dict(resolved_params[0])

--- a/src/normlite/sql/compiler.py
+++ b/src/normlite/sql/compiler.py
@@ -618,13 +618,45 @@ class NotionCompiler(SQLCompiler):
                 with self._compiling(new_state=_CompileState.COMPILING_WHERE):
                     # emit the JSON code for the filter object of the query
                     # in the right context
-                    filter_obj = select._whereclause.expression._compiler_dispatch(self)
-                    if parent_tables == {select._table}:
-                        # for the left table, add "filter" to the payload for the databases.query
-                        payload['filter'] = filter_obj
+                    if (
+                        select._joins
+                        and isinstance(expression, BooleanClauseList)
+                        and expression.operator == "and"
+                        and parent_tables == {select._table, select._right}
+                    ):
+                        # Compound AND spanning both join sides: split per-clause.
+                        # Left-only conjuncts narrow phase-1 to a SUPERSET of the
+                        # answer, so push them into payload['filter']; the remaining
+                        # conjuncts are held back in join_right_filter for client-side
+                        # evaluation after the merge. (See #311.)
+                        left_conjuncts = [
+                            clause._compiler_dispatch(self)
+                            for clause in expression.clauses
+                            if _get_expression_parent_tables(clause) == {select._table}
+                        ]
+                        right_conjuncts = [
+                            clause._compiler_dispatch(self)
+                            for clause in expression.clauses
+                            if _get_expression_parent_tables(clause) != {select._table}
+                        ]
+                        if left_conjuncts:
+                            payload['filter'] = (
+                                left_conjuncts[0] if len(left_conjuncts) == 1
+                                else {"and": left_conjuncts}
+                            )
+                        if right_conjuncts:
+                            compiled_dict["join_right_filter"] = (
+                                right_conjuncts[0] if len(right_conjuncts) == 1
+                                else {"and": right_conjuncts}
+                            )
                     else:
-                        # for the right table, stash the filter for filtering after merging
-                        compiled_dict["join_right_filter"] = filter_obj
+                        filter_obj = expression._compiler_dispatch(self)
+                        if parent_tables == {select._table}:
+                            # for the left table, add "filter" to the payload for the databases.query
+                            payload['filter'] = filter_obj
+                        else:
+                            # for the right table, stash the filter for filtering after merging
+                            compiled_dict["join_right_filter"] = filter_obj
 
         projection = self._compiler_state.stmt._projection
 
@@ -673,9 +705,26 @@ class NotionCompiler(SQLCompiler):
                     f"Cannot route ORDER BY expression: no source table could be "
                     f"determined for {type(order_by_clause).__name__}."
                 )
- 
-            if parent_tables == {select._table}:
-                sorts_obj = select._order_by._compiler_dispatch(self)
+            
+            # Sort pushability is POSITIONAL: only the LEADING RUN of left-table
+            # keys can ride in phase-1 (databases.query sorts by left-table
+            # properties only). Stop the prefix at the first key that isn't purely
+            # left-table — a right-side (or mixed) primary key makes the remaining
+            # sort a client-side concern. This unifies the single-table case (every
+            # key is left-table, so the whole sort is pushed) with the join case.
+            sorts_obj = []
+            for clause in order_by_clause.clauses:
+                if _get_expression_parent_tables(clause) != {select._table}:
+                    break
+                sorts_obj.append(clause._compiler_dispatch(self))
+
+            compiled_dict["join_right_sorts"] = [
+                clause._compiler_dispatch(self)
+                for clause in order_by_clause.clauses
+                if _get_expression_parent_tables(clause) != {select._table}
+            ]
+
+            if sorts_obj:
                 payload['sorts'] = sorts_obj
 
         compiled_dict ["payload"] = payload
@@ -970,7 +1019,6 @@ class NotionCompiler(SQLCompiler):
     
     def _compile_table_columns(self, user_cols: ReadOnlyColumnCollection) -> dict:
         from normlite.sql.type_api import Relation
-        from normlite.sql.schema import ForeignKeyConstraint
 
         # resolve oids for the all referenced columns         
         stmt_table = self._compiler_state.stmt._table

--- a/src/normlite/sql/dml.py
+++ b/src/normlite/sql/dml.py
@@ -27,7 +27,7 @@ from typing import Any, Callable, Mapping, NoReturn, Optional, Protocol, Self, S
 import collections.abc as collections_abc
 
 import warnings
-from normlite.exceptions import ArgumentError, NoSuchColumnError
+from normlite.exceptions import ArgumentError
 from normlite.sql.base import Executable, ClauseElement, generative
 from normlite.sql.elements import BinaryExpression, BindParameter, BooleanClauseList, ColumnElement
 from normlite.sql.resultschema import ResultColumn, SchemaInfo
@@ -765,6 +765,7 @@ class Select(HasTable, ExecutableClauseElement):
             self._joins[0],
             self._projection,
             context.join_right_filter,
+            context.join_right_sorts
         )
         context._join_execution = join_execution
 
@@ -1038,10 +1039,12 @@ class JoinExecution:
         join: Join,
         projection: Optional[ReadOnlyColumnCollection],
         right_filter: Optional[dict],
+        right_sorts: Optional[list[dict]]
     ):
         self._join = join
         self._projection = projection
         self._right_filter = right_filter
+        self._right_sorts = right_sorts
 
         # ``projection`` is None only for low-level callers that mean "project
         # everything" (e.g. JoinExecution unit tests). Fall back to all user
@@ -1121,6 +1124,9 @@ class JoinExecution:
 
         .. versionadded:: 0.11.0
         """
+        from normlite.notion_sdk.client import EMPTY_TEXT, EMPTY_NUMBER
+        from normlite.sql.type_api import type_mapper
+
         merged_schema = SchemaInfo.from_join(
             self._join.left,
             self._join.right,
@@ -1144,6 +1150,43 @@ class JoinExecution:
                 r for r in merged_rows
                 if self._right_side_passes(r, right_getters, right_cols)
             ]
+
+        if self._right_sorts is not None:
+            # apply sorting using the held-back right ORDER BY keys
+            # the sort key is obtained with the getters using the merged_schema
+            right_cols = [c for c in merged_schema.columns if c.table is self._join.right]
+            by_bare = {c.bare_name: c for c in right_cols}
+            for sort in reversed(self._right_sorts):
+                 # identity, keyed by the sort's own property
+                col = by_bare[sort["property"]]
+
+                # merged name — survives collision
+                getter = merged_schema.column_getter(col.name)
+                
+                direction = sort.get("direction", "ascending")
+                reverse = direction == "descending"
+
+                
+                def sort_key(row: tuple[dict]) -> tuple[bool, Any]:
+                    result_processor = type_mapper[col.type_code].result_processor()
+                    value = getter(row)
+
+                    # result processor needs the property value
+                    value = result_processor(value)
+                    # Empties-first/last sentinel, inherited from
+                    # _extract_sort_value. For a right-side TITLE key this branch
+                    # is currently UNREACHABLE: an empty/None right title is
+                    # unconstructable through the public interface (insert
+                    # title=None is rejected by the client; title="" yields a
+                    # non-empty list). Kept for parity with the shared sort-value
+                    # semantics and for nullable types if they become sortable
+                    # right-side keys. See ADR-0005 / the unreachable-empty-title
+                    # boundary; not covered by a test because the input can't be
+                    # built.
+                    is_empty = value in (None, EMPTY_TEXT, EMPTY_NUMBER)
+                    return (is_empty, value)
+
+                merged_rows.sort(key=sort_key, reverse=reverse)
 
         return (merged_schema, merged_rows)
 
@@ -1322,4 +1365,3 @@ def _join_errorhandler(
         return                       
 
     raise errorvalue                 # propagate everything else
-

--- a/tests/unit/engine/test_join_pipeline.py
+++ b/tests/unit/engine/test_join_pipeline.py
@@ -927,3 +927,114 @@ def test_join_keeps_projected_name_bare_when_collision_is_unprojected(engine: En
     m = row.mapping()
     assert m["name"] == "Galileo Galilei"
     assert m["director"] == "Vincenzo Galilei"
+
+
+def test_inner_join_order_by_left_then_right_breaks_ties_by_right_key(engine: Engine):
+    # ORDER BY students.name, courses.title. The LEFT key is primary (pushed to
+    # phase-1); the RIGHT key is the tie-break, which can only be applied
+    # client-side AFTER the join. One student enrolled in two courses yields two
+    # same-name pairs, so the trailing right key alone decides their order.
+    #
+    # The relation list is seeded in the REVERSE of title order, so the correct
+    # result cannot be the incidental retrieval/merge order — it must be ACTIVELY
+    # ordered by the trailing right key.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        physics_oid = (
+            connection.execute(
+                insert(courses).values(title="Physics").returning(courses.c.object_id)
+            ).first().object_id
+        )
+        astronomy_oid = (
+            connection.execute(
+                insert(courses).values(title="Astronomy").returning(courses.c.object_id)
+            ).first().object_id
+        )
+
+        # relation list deliberately in REVERSE title order: Physics before Astronomy
+        connection.execute(
+            insert(students).values(
+                name="Galileo",
+                enrolled_in=[physics_oid, astronomy_oid],
+            )
+        )
+
+        result = connection.execute(
+            select(students, courses)
+            .join(students.c.enrolled_in)
+            .order_by(students.c.name.asc(), courses.c.title.asc())
+        )
+        rows = result.fetchall()
+
+    # both pairs share the name, so the trailing right key (title) orders them:
+    # Astronomy precedes Physics ascending.
+    assert [r.title for r in rows] == ["Astronomy", "Physics"]
+
+
+def test_inner_join_order_by_left_then_right_breaks_ties_by_right_key_descending(engine: Engine):
+    # Same shape as the ascending tie-break above, but the trailing right key is
+    # DESCENDING. The held-back right key is applied client-side AFTER the join,
+    # so this pins that the client-side sort honors direction (reverse), not just
+    # that it sorts at all. Empties placement is NOT asserted here: an empty/None
+    # right-side title is unconstructable through the public interface (insert
+    # title=None is rejected by the client; title="" is non-empty), so there is
+    # no black-box input to exercise it. See ADR-0005 / the unreachable-empty-
+    # title boundary.
+    metadata = MetaData()
+    courses = Table(
+        "courses",
+        metadata,
+        Column("title", String(is_title=True)),
+    )
+    students = Table(
+        "students",
+        metadata,
+        Column("name", String(is_title=True)),
+        Column("enrolled_in", Relation(), ForeignKey("courses.object_id")),
+    )
+    metadata.create_all(engine)
+
+    with engine.connect() as connection:
+        physics_oid = (
+            connection.execute(
+                insert(courses).values(title="Physics").returning(courses.c.object_id)
+            ).first().object_id
+        )
+        astronomy_oid = (
+            connection.execute(
+                insert(courses).values(title="Astronomy").returning(courses.c.object_id)
+            ).first().object_id
+        )
+
+        # relation list seeded in ASCENDING title order, so the DESC result
+        # cannot be the incidental retrieval/merge order.
+        connection.execute(
+            insert(students).values(
+                name="Galileo",
+                enrolled_in=[astronomy_oid, physics_oid],
+            )
+        )
+
+        result = connection.execute(
+            select(students, courses)
+            .join(students.c.enrolled_in)
+            .order_by(students.c.name.asc(), courses.c.title.desc())
+        )
+        rows = result.fetchall()
+
+    # both pairs share the name, so the trailing right key (title) orders them:
+    # Physics precedes Astronomy descending.
+    assert [r.title for r in rows] == ["Physics", "Astronomy"]

--- a/tests/unit/sql/test_join_compilation.py
+++ b/tests/unit/sql/test_join_compilation.py
@@ -1,3 +1,4 @@
+import json
 import pdb
 import uuid
 
@@ -7,7 +8,7 @@ from normlite import Relation, ForeignKey
 from normlite.exceptions import ArgumentError, CompileError
 from normlite.sql.compiler import NotionCompiler
 from normlite.sql.dml import Join, select
-from normlite.sql.elements import ColumnElement, OrderByExpression
+from normlite.sql.elements import ColumnElement, OrderByExpression, or_
 from normlite.sql.schema import Column, MetaData, Table
 from normlite.sql.type_api import String
 
@@ -236,26 +237,6 @@ def test_right_side_where_filter_stays_out_of_phase_one_query_payload(
     # phase-1 payload must carry no filter built from a right-table column
     assert "filter" not in asdict["payload"]
 
-def test_mixed_left_right_where_compound_stays_out_of_phase_one_regardless_of_order(
-    students: Table, courses: Table
-):
-    # Compound WHERE touching BOTH sides; a right-table column is involved, so the
-    # whole compound must stay out of phase-1, and routing must NOT depend on order.
-    students._sys_columns["object_id"]._value = str(uuid.uuid4())
-    left_then_right = (
-        select(students, courses).join(students.c.enrolled_in)
-        .where(students.c.name == "Galileo").where(courses.c.title == "Astronomy")
-        .compile(NotionCompiler()).as_dict()
-    )
-    students._sys_columns["object_id"]._value = str(uuid.uuid4())
-    right_then_left = (
-        select(students, courses).join(students.c.enrolled_in)
-        .where(courses.c.title == "Astronomy").where(students.c.name == "Galileo")
-        .compile(NotionCompiler()).as_dict()
-    )
-    assert "filter" not in left_then_right["payload"]
-    assert "filter" not in right_then_left["payload"]
-
 def test_where_expression_with_no_source_table_raises_compile_error(students: Table):
     students._sys_columns["object_id"]._value = str(uuid.uuid4())
     class _UnknownExpr(ColumnElement):
@@ -283,25 +264,24 @@ def test_right_side_order_by_stays_out_of_phase_one_query_payload(
     # phase-1 payload must carry no sort built from a right-table column
     assert "sorts" not in asdict["payload"]
 
-def test_mixed_left_right_order_by_stays_out_of_phase_one_regardless_of_order(
+def test_order_by_right_then_left_pushes_nothing_into_phase_one(
     students: Table, courses: Table
 ):
-    # Compound ORDER BY touching BOTH sides; a right-table column is involved, so the
-    # whole sort must stay out of phase-1, and routing must NOT depend on clause order.
+    # ORDER BY with a RIGHT key FIRST. The primary sort key is a right-table
+    # property databases.query cannot sort by, so the leading run is empty and
+    # NOTHING is pushable. The trailing left key is only a secondary tie-break
+    # under a client-side primary, so it cannot ride in phase-1 either. This is
+    # the mirror of `ORDER BY left, right` (which pushes the left prefix) — sort
+    # routing is positional, NOT set-membership.
     students._sys_columns["object_id"]._value = str(uuid.uuid4())
-    left_then_right = (
-        select(students, courses).join(students.c.enrolled_in)
-        .order_by(students.c.name.asc(), courses.c.title.asc())
-        .compile(NotionCompiler()).as_dict()
-    )
-    students._sys_columns["object_id"]._value = str(uuid.uuid4())
-    right_then_left = (
+    asdict = (
         select(students, courses).join(students.c.enrolled_in)
         .order_by(courses.c.title.asc(), students.c.name.asc())
         .compile(NotionCompiler()).as_dict()
     )
-    assert "sorts" not in left_then_right["payload"]
-    assert "sorts" not in right_then_left["payload"]
+
+    # a leading right-table key stops the prefix immediately: no sorts in phase-1
+    assert "sorts" not in asdict["payload"]
 
 def test_order_by_expression_with_no_source_table_raises_compile_error(students: Table):
     students._sys_columns["object_id"]._value = str(uuid.uuid4())
@@ -312,3 +292,83 @@ def test_order_by_expression_with_no_source_table_raises_compile_error(students:
     stmt = select(students).order_by(OrderByExpression(_UnknownExpr(), "asc"))
     with pytest.raises(CompileError, match=r"route ORDER BY expression"):
         stmt.compile(NotionCompiler())
+
+def test_compound_and_where_pushes_only_left_conjunct_into_phase_one(
+      students: Table, courses: Table
+  ):
+      students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+      # Compound WHERE = a LEFT (students) conjunct AND a RIGHT (courses) conjunct.
+      # The left conjunct only narrows the phase-1 candidate set to a SUPERSET of the
+      # final answer, so databases.query may safely carry it; the right conjunct must
+      # be answered client-side after the join.
+      stmt = (
+          select(students, courses)
+          .join(students.c.enrolled_in)
+          .where(students.c.name == "Galileo")      # LEFT  — pushable
+          .where(courses.c.title == "Astronomy")    # RIGHT — client-side only
+      )
+
+      asdict = stmt.compile(NotionCompiler()).as_dict()
+
+      phase_one_filter = json.dumps(asdict["payload"].get("filter"))
+      held_back = json.dumps(asdict.get("join_right_filter"))
+
+      # phase-1 query carries the left (students.name) condition ...
+      assert '"property": "name"' in phase_one_filter
+      # ... but NOT the right (courses.title) condition.
+      assert '"property": "title"' not in phase_one_filter
+
+      # the right (courses.title) condition is held back for client-side evaluation.
+      assert '"property": "title"' in held_back
+
+def test_compound_or_spanning_both_sides_pushes_nothing_into_phase_one(
+    students: Table, courses: Table
+):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    # Compound OR spanning BOTH sides. A row qualifies if EITHER side holds, so
+    # narrowing phase-1 to just the left disjunct would silently drop rows that
+    # match only the right one — wrong answer, no error. Unlike AND, an OR that
+    # touches the right table must stay WHOLLY client-side: push nothing.
+    stmt = (
+        select(students, courses)
+        .join(students.c.enrolled_in)
+        .where(or_(students.c.name == "Galileo", courses.c.title == "Astronomy"))
+    )
+
+    asdict = stmt.compile(NotionCompiler()).as_dict()
+
+    # phase-1 query carries NO filter at all ...
+    assert "filter" not in asdict["payload"]
+
+    # ... and the whole OR is held back for client-side eval, with BOTH disjuncts
+    # still present and joined by "or" — i.e. the connective was never split.
+    held_back = asdict["join_right_filter"]
+    assert "or" in held_back
+    assert '"property": "name"' in json.dumps(held_back)
+    assert '"property": "title"' in json.dumps(held_back)
+
+def test_order_by_left_then_right_pushes_only_left_prefix_into_phase_one(
+    students: Table, courses: Table
+):
+    students._sys_columns["object_id"]._value = str(uuid.uuid4())
+
+    # ORDER BY with a LEFT key first, a RIGHT key second. Sort pushability is
+    # POSITIONAL, not set-membership: only the LEADING RUN of left-table keys can
+    # ride in phase-1 (databases.query sorts by left properties only). The primary
+    # left key is pushable; the trailing right key must STOP the prefix and be left
+    # for a client-side stable sort after the join.
+    stmt = (
+        select(students, courses)
+        .join(students.c.enrolled_in)
+        .order_by(students.c.name.asc(), courses.c.title.asc())
+    )
+
+    asdict = stmt.compile(NotionCompiler()).as_dict()
+
+    # phase-1 sorts carry EXACTLY the leading left (students.name) key — the
+    # right (courses.title) key is NOT pushed.
+    assert asdict["payload"].get("sorts") == [
+        {"property": "name", "direction": "ascending"}
+    ]

--- a/tests/unit/sql/test_join_execution.py
+++ b/tests/unit/sql/test_join_execution.py
@@ -1,7 +1,7 @@
 """Seam-level tests for the JoinExecution object (issue #314, ADR-0008).
 
 These exercise JoinExecution through its public interface only:
-    JoinExecution(join, projection, right_filter)
+    JoinExecution(join, projection, right_filter, right_sorts)
         .prepare(left_rows)   -> bulk_params
         .assemble(right_rows) -> (merged_schema, merged_rows)
 
@@ -60,7 +60,7 @@ def test_prepare_turns_left_rows_into_deduplicated_retrieve_batch():
     ]
 
     # Act: build the seam object from config only, then feed it phase-1 rows.
-    join_execution = JoinExecution(join, projection=None, right_filter=None)
+    join_execution = JoinExecution(join, projection=None, right_filter=None, right_sorts=None)
     bulk_params = join_execution.prepare(left_rows)
 
     # Assert: each distinct target id appears exactly once, in first-seen
@@ -128,7 +128,7 @@ def test_assemble_merges_the_prepared_left_rows_with_the_retrieved_right_rows():
 
     # Act: prepare seeds the phase-1 state; assemble takes ONLY the phase-2
     # rows and must reuse the left rows captured across the dispatch boundary.
-    join_execution = JoinExecution(join, projection=projection, right_filter=None)
+    join_execution = JoinExecution(join, projection=projection, right_filter=None, right_sorts=None)
     join_execution.prepare(left_rows)
     merged_schema, merged_rows = join_execution.assemble(right_rows)
 
@@ -210,7 +210,7 @@ def test_assemble_applies_right_filter_dropping_rows_whose_right_side_fails():
     right_filter = {"property": "title", "title": {"is_not_empty": True}}
 
     # Act
-    join_execution = JoinExecution(join, projection=projection, right_filter=right_filter)
+    join_execution = JoinExecution(join, projection=projection, right_filter=right_filter, right_sorts=None)
     join_execution.prepare(left_rows)
     _, merged_rows = join_execution.assemble(right_rows)
 
@@ -280,7 +280,7 @@ def test_assemble_outer_join_none_fills_a_dangling_left_row_that_inner_drops():
     right_rows = [right_row("Astronomy", "c-astro")]
 
     # Act
-    je = JoinExecution(join, projection=projection, right_filter=None)
+    je = JoinExecution(join, projection=projection, right_filter=None, right_sorts=None)
     je.prepare(left_rows)
     _, merged_rows = je.assemble(right_rows)
 
@@ -305,7 +305,7 @@ def test_assemble_outer_join_none_fills_a_left_row_with_an_empty_relation():
     right_rows = [right_row("Astronomy", "c-astro")]
 
     # Act
-    je = JoinExecution(join, projection=projection, right_filter=None)
+    je = JoinExecution(join, projection=projection, right_filter=None, right_sorts=None)
     je.prepare(left_rows)
     _, merged_rows = je.assemble(right_rows)
 
@@ -325,7 +325,7 @@ def test_assemble_outer_join_does_not_none_fill_a_row_that_already_matched():
     right_rows = [right_row("Astronomy", "c-astro")]
 
     # Act
-    je = JoinExecution(join, projection=projection, right_filter=None)
+    je = JoinExecution(join, projection=projection, right_filter=None, right_sorts=None)
     je.prepare(left_rows)
     _, merged_rows = je.assemble(right_rows)
 


### PR DESCRIPTION
Closes #311.

Splits compound WHERE and ORDER BY by source table at compile time: the
left-prefix rides in phase-1 (`databases.query`) and the right remainder is
held back for client-side application after the merge.

## What changed
- **compiler**: split compound `AND` WHERE per-clause (left conjuncts → payload
  `filter`, right conjuncts → `join_right_filter`); ORDER BY pushability is
  positional — only the leading run of left-table keys is pushed, the rest go to
  `join_right_sorts`.
- **dml**: `JoinExecution.assemble()` applies the held-back right sort keys.
  Columns are selected by **identity** (provenance) with the getter taken at the
  merged name, so a name collision doesn't crash (ADR-0009); descending is honored
  via `reverse` over an `(is_empty, value)` key. The empties sentinel is kept with
  a boundary comment — unreachable for a TITLE key since an empty/None right title
  is unconstructable through the public API (ADR-0005).
- **engine**: `ExecutionContext` gains `join_right_sorts`, defaulted to `None` in
  `__init__` (the conditional compiled-dict write alone left it unset on the common
  path).
- `JoinExecution.__init__` takes `right_sorts` as a required positional, matching
  the explicit-config convention of `right_filter`.

## Dual scope note
This work lives on the `refactor/issue-319/right-side-where-name-collision`
branch, which previously carried the **#319 / ADR-0009** right-side-WHERE
collision work. That work has **already merged via #321**; main now contains it,
so this PR's diff is **only the #311 commit** (`b079c2f`) on top. The shared branch
name reflects that #311 built directly on the (then-unmerged) ADR-0009 provenance
machinery it reuses for identity-based column selection.

## Tests
Ascending + descending right-key tie-break pipeline tests and per-clause compound
routing compilation tests. Full unit suite green: **682 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)