### PR TITLE
feat: streaming result over token pagination (ADR-0010) — slices 1–5

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -329,6 +329,14 @@ multiple Notion pages per logical batch. `page_size` is not a user knob in v1. I
 the request body only when `yield_per` is set, on a per-request payload copy (never smearing onto
 the caller's dict); drain-all (`yield_per is None`) leaves the caller's payload `page_size` alone.
 
+The name collides: a `page_size` **execution option** also lives in the options cascade (default
+100, its cascade/merge pinned by `test_exec_opts.py`) — but it is **vestigial, inert on the query
+path**: it never reaches the request body. The body's `page_size` comes from the compiler (the
+Notion-max 100) and, when streaming, from the `Cursor` overriding it with `min(yield_per or 100,
+100)`. So `yield_per` is the only effective page-size control — when both are set, `yield_per`
+wins. Declaring streaming on `execution_options` therefore means `stream_results`/`yield_per`,
+**not** `page_size`; retiring the vestigial option is a deferred cleanup (it is still test-pinned).
+
 **Pagination is an `execute`-only concern.** `executemany` is the non-paginated bulk-write path:
 one client call per parameter set, no `next_cursor` walk, skip-and-continue error handling. It
 returns no streamable result set (per DBAPI 2.0, `executemany` is not for row-returning ops), so

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -325,17 +325,28 @@ Two behaviors share one page-fetch seam:
 
 `page_size` is **internal and capped**: `min(yield_per or 100, 100)`. `yield_per` (the user's
 logical batch) is decoupled from `page_size` (Notion transport, ≤100); `yield_per > 100` pulls
-multiple Notion pages per logical batch. `page_size` is not a user knob in v1.
+multiple Notion pages per logical batch. `page_size` is not a user knob in v1. It is injected into
+the request body only when `yield_per` is set, on a per-request payload copy (never smearing onto
+the caller's dict); drain-all (`yield_per is None`) leaves the caller's payload `page_size` alone.
+
+**Pagination is an `execute`-only concern.** `executemany` is the non-paginated bulk-write path:
+one client call per parameter set, no `next_cursor` walk, skip-and-continue error handling. It
+returns no streamable result set (per DBAPI 2.0, `executemany` is not for row-returning ops), so
+neither drain-all nor streaming applies — this boundary is **by design, not deferred**.
 
 ### Pagination — internal representation
 A paginated query is **one streaming `ResultSet`**, not one `ResultSet` per page — pages are an
 axis orthogonal to the `Cursor._result_sets` list, which keeps its existing meaning (one entry per
 statement / `executemany` batch). `nextset()` still means "next statement," untouched. The
-`ResultSet` grows a page-fetch seam: a `_fetch_next(start_cursor)` closure (built by the `Cursor`,
-which owns the `operation`/`parameters`/client and injects `start_cursor`/`page_size` into the
-POST **body** of `databases.query`), plus `next_cursor`/`has_more`/`exhausted` state. The **first
-page is always eager** (it establishes the description and is where `NotionError`→DBAPI translation
-happens). Subsequent pages are eager (drain-all) or lazy (streaming).
+page-fetch seam is a standalone **`PageIterator`** (`notiondbapi/page_iterator.py`): the `Cursor`
+builds a `page_fetcher(start_cursor)` closure (it owns `operation`/`parameters`/client and injects
+`start_cursor`/`page_size` into the POST **body** of `databases.query`) and holds the iterator as
+`Cursor._page_iter`; the `PageIterator` carries `next_cursor`/`has_more`/`exhausted`/`page_size`.
+`ResultSet` grew `extend_from_json(page)` to append a page's rows into its buffer in place. The
+**first page is always eager** (it establishes the description and is where `NotionError`→DBAPI
+translation happens). Subsequent pages are eager (the drain-all `for` loop in `execute`) or lazy:
+`fetchone` pulls the next page only when the in-memory buffer drains, and `fetchall` drives that
+pull to completion.
 
 ### Pagination — rowcount & errors
 - **`rowcount`.** Drain-all: accurate immediately. Streaming: **-1 until the `ResultSet` is

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -296,6 +296,68 @@ remains the "create a new file-backed engine" path regardless of `auto_load`.
 
 ---
 
+## Pagination
+
+### Streaming result over token pagination
+normlite's answer to large result sets. Modelled on SQLAlchemy's server-side cursor
+(`stream_results` / `yield_per`) but **explicitly not** a real server-side cursor: Notion holds
+no cursor object and offers no `FETCH`. The mechanism is **token pagination** — the DBAPI cursor
+lazily requests the next Notion page (`start_cursor` ← previous response's `next_cursor`) only when
+its in-memory buffer drains, so the caller iterates `Row`s without the whole set being resident.
+
+Notion's pagination contract (the wire shape every paginated endpoint returns):
+`object: "list"`, `results: [...]`, `has_more: bool`, `next_cursor: str | None` (present only when
+`has_more` is true), with request params `start_cursor` and `page_size` (default **100**, max
+**100**). "Server-side cursor" may be used in *user-facing docs* as an analogy, but never as the
+canonical domain term — the result set is **not** stable across page requests.
+
+### Drain-all (default) vs streaming (opt-in)
+Two behaviors share one page-fetch seam:
+- **Drain-all (default).** The DBAPI `Cursor` pulls every page (`start_cursor` ← previous
+  `next_cursor`) until `has_more` is false, before the caller sees rows. This makes *every*
+  existing caller — joins, two-phase `Delete`/`Update`, reflection, bootstrap — correct against
+  pagination for free, and preserves today's "you get everything" semantics and `rowcount`.
+- **Streaming (opt-in).** Enabled via `execution_options(stream_results=True)` or `yield_per=N`
+  (`yield_per` implies `stream_results`), mirroring SQLAlchemy. Pages are pulled lazily as the
+  result is iterated. **Select-only**: mutations, join phase-1 scans, reflection and bootstrap
+  always force drain-all even if `stream_results=True` is set on the connection — phase 1 must
+  know the full match set before phase 2 runs.
+
+`page_size` is **internal and capped**: `min(yield_per or 100, 100)`. `yield_per` (the user's
+logical batch) is decoupled from `page_size` (Notion transport, ≤100); `yield_per > 100` pulls
+multiple Notion pages per logical batch. `page_size` is not a user knob in v1.
+
+### Pagination — internal representation
+A paginated query is **one streaming `ResultSet`**, not one `ResultSet` per page — pages are an
+axis orthogonal to the `Cursor._result_sets` list, which keeps its existing meaning (one entry per
+statement / `executemany` batch). `nextset()` still means "next statement," untouched. The
+`ResultSet` grows a page-fetch seam: a `_fetch_next(start_cursor)` closure (built by the `Cursor`,
+which owns the `operation`/`parameters`/client and injects `start_cursor`/`page_size` into the
+POST **body** of `databases.query`), plus `next_cursor`/`has_more`/`exhausted` state. The **first
+page is always eager** (it establishes the description and is where `NotionError`→DBAPI translation
+happens). Subsequent pages are eager (drain-all) or lazy (streaming).
+
+### Pagination — rowcount & errors
+- **`rowcount`.** Drain-all: accurate immediately. Streaming: **-1 until the `ResultSet` is
+  exhausted** (`has_more` false), then the true sum. `preserve_rowcount` memoizing -1 mid-stream
+  is correct, not a bug. The two-phase `Delete`/`Update` "rows matched" guarantee is meaningful
+  only on the drain-all path (mutations never stream).
+- **Mid-stream errors.** A page fetch that fails *during iteration* routes through the centralized
+  `_translate_notion_error` and **propagates** (does not skip-and-continue like `executemany`) —
+  a broken page makes all later pages unreachable. Already-yielded rows stay yielded.
+
+### Pagination — boundaries (deferred)
+- GET-style paginated endpoints (list users, block children) take `start_cursor`/`page_size` as
+  **`query_params`**, not body; the v1 closure hard-codes body-injection for `databases.query` only.
+- `search` and `_get_by_title` stay single-page (`has_more: False`) in the fake; only
+  `databases_query` simulates pagination.
+- `CursorResult.partitions(n)` (idiomatic batch consumer) deferred; `__iter__`/`fetchone`/
+  `fetchmany` stream, `all()`/`fetchall()` materialize-by-draining (documented, not blocked).
+
+See [[adr-0010-streaming-result-token-pagination]].
+
+---
+
 ## DML Construct Decisions
 
 ### Update — partial VALUES

--- a/docs/adr/0010-streaming-result-token-pagination.md
+++ b/docs/adr/0010-streaming-result-token-pagination.md
@@ -141,6 +141,19 @@ silently clamp.
   `ResultSet`, `Cursor`-owned seam, first page eager, `page_size` injected into the body) is
   unchanged; only the object boundary moved. `PageIterator._page_size` now carries the clamped
   size; `fetchone` pulls on buffer-drain and `fetchall` drives the pull to completion.
+- **The `page_size` *execution option* is vestigial, not the streaming knob.** A `page_size`
+  key predates this ADR in the engine→connection→statement options cascade (declared on the
+  `execution_options` overloads, default 100, its cascade/merge/precedence pinned by
+  `test_exec_opts.py`), but it is **inert on the query path**: it never reaches the
+  `databases.query` body. The transport page size is set entirely by the compiler — which emits
+  the Notion-max `page_size: 100` into every query body — and, on the streaming path, by the
+  `Cursor` overriding that with `min(yield_per or 100, 100)`. So when both are set, **`yield_per`
+  wins and the `page_size` option changes nothing on the wire** — consistent with the Decision's
+  "`page_size` internal, not a user knob" and rejected Alternative D. Consequence for the
+  Slice-4 streaming cascade: the options to declare on the `execution_options` overloads are
+  `stream_results`/`yield_per`, **not** a re-blessed `page_size`. Retiring the vestigial
+  `page_size` option (and its overload entries) is a separate cleanup, deferred because
+  `test_exec_opts.py` still pins its cascade behavior.
 - **Out of scope (named boundaries):** GET-style paginated endpoints (body vs `query_params`
   injection); `search`/`_get_by_title` pagination; `CursorResult.partitions(n)`; real Notion
   integration and the relation-property `has_more` truncation

--- a/docs/adr/0010-streaming-result-token-pagination.md
+++ b/docs/adr/0010-streaming-result-token-pagination.md
@@ -1,0 +1,125 @@
+# ADR-0010: Streaming result over Notion token pagination
+
+**Status:** Accepted
+**Date:** 2026-06-23
+
+---
+
+## Context
+
+normlite ignores Notion pagination entirely. `Cursor.execute()` (`notiondbapi/dbapi2.py`)
+makes exactly one client call and appends exactly one `ResultSet`, a fully-materialized
+`list[tuple]`. The fake `InMemoryNotionClient.databases_query` hard-codes
+`next_cursor: None, has_more: False` and returns every matching page in one response.
+
+This is wrong on two independent axes, which a single feature request ("expose Notion
+pagination as a server-side cursor like SQLAlchemy") conflated:
+
+1. **Correctness.** Notion's `databases.query` is paginated: `page_size` defaults to and
+   caps at **100**, and the response carries `has_more` / `next_cursor`. Every internal
+   consumer that calls `databases.query` — joins, two-phase `Delete`/`Update`, reflection,
+   bootstrap — reads only the first response's `results` and ignores `has_more`. Against a
+   real Notion workspace with >100 matches they would **silently drop rows**. This is a
+   latent bug today only because the fake never truncates.
+
+2. **Feature.** Users want SQLAlchemy-style bounded-memory iteration over large result
+   sets — fetch pages on demand while iterating, rather than buffering everything.
+
+The dependency that forces both into one slice: the tracer bullet ships against in-memory
+clients only (no real Notion integration yet — see CONTEXT.md "Deferred — `has_more`
+truncation" and [ADR-0007](./0007-join-dangling-fk-propagation.md)). The *only* way to
+exercise either axis end-to-end is to teach the fake to paginate — and the moment it does,
+every "read page 1 only" consumer becomes a >100-row test away from breaking.
+
+A terminology trap also had to be settled: Notion has **no server-side cursor**. It holds
+no cursor object, offers no `FETCH`, and gives no stability guarantee between page requests.
+"Server-side cursor" is a borrowed metaphor; what we can actually deliver is lazy streaming
+over **token pagination**.
+
+## Decision
+
+**Make the DBAPI cursor drain all pages by default; layer opt-in lazy streaming on top; model
+a paginated query as one streaming `ResultSet`.**
+
+- **Canonical term: "streaming result over token pagination."** Not "server-side cursor"
+  (reserved for user-facing docs analogy, with the not-stable caveat). The result set is not
+  stable across page requests.
+
+- **Drain-all by default.** `Cursor.execute()` loops `start_cursor` ← previous `next_cursor`
+  until `has_more` is false. This makes every existing caller correct against pagination for
+  free and preserves today's "you get everything" semantics and the `rowcount` contract.
+
+- **Streaming is opt-in and Select-only.** New `ExecutionOptions` keys `stream_results: bool`
+  and `yield_per: int` (`yield_per` implies `stream_results`), reusing the existing
+  engine→connection→statement options cascade. Honored **only** on the row-returning `Select`
+  read path. Two-phase `Delete`/`Update`, join phase-1 scans, reflection and bootstrap force
+  drain-all even when `stream_results=True` is inherited from the connection — phase 1 must
+  know the full match set before phase 2.
+
+- **One streaming `ResultSet`, not one per page.** Pages are orthogonal to the
+  `Cursor._result_sets` list, which keeps meaning "one entry per statement / `executemany`
+  batch"; `nextset()` is untouched. `ResultSet` grows a page-fetch seam: a
+  `_fetch_next(start_cursor)` closure built by the `Cursor` (which owns
+  `operation`/`parameters`/client and injects `start_cursor`/`page_size` into the
+  `databases.query` POST **body**), plus `next_cursor`/`has_more`/`exhausted` state. The
+  **first page is always eager** (establishes the description; is where the page-1
+  `NotionError`→DBAPI translation happens). Later pages are eager (drain-all) or lazy
+  (streaming).
+
+- **`page_size` internal and capped.** `min(yield_per or 100, 100)`. `yield_per` (logical
+  batch) is decoupled from `page_size` (transport, ≤100); `yield_per > 100` pulls multiple
+  Notion pages per batch. Not a user knob in v1.
+
+- **`rowcount` honors the pre-existing docstring contract.** Drain-all: accurate immediately.
+  Streaming: **-1 until the `ResultSet` is exhausted**, then the true sum. `preserve_rowcount`
+  memoizing -1 mid-stream is correct.
+
+- **Mid-stream errors propagate.** A lazy page fetch that fails during iteration routes
+  through the centralized `_translate_notion_error` and **raises** (no skip-and-continue like
+  `executemany`) — a broken page makes all later pages unreachable. Already-yielded rows stay.
+
+- **Fake simulates pagination for `databases_query` only.** Honors `page_size`/`start_cursor`,
+  slices its filtered+sorted pages, emits real `next_cursor`/`has_more`. Token is an opaque
+  offset-encoded string (never reaches users). Default `page_size = 100` (matches Notion; tiny
+  test stores keep `has_more` false → zero behavior change for current callers). View is
+  recomputed and offset-sliced each call (faithfully non-stable, not a frozen snapshot).
+
+## Alternatives Considered
+
+**A. Always lazy (no drain-all default).** Rejected: would leave every internal full-scan
+consumer (joins, two-phase DML) reading page 1 only — shipping the correctness bug — and
+would break `rowcount` for mutations. Drain-all is the honest, back-compatible foundation;
+streaming is the additive feature.
+
+**B. One `ResultSet` per page (append each page to `_result_sets`).** Tempting because
+`_iter_all`/`rowcount`/`fetchone`+`nextset` already span the list, so it "just works" with
+no new code. Rejected: `nextset()` and the multi-`ResultSet` list already mean "next
+statement / `executemany` batch." Making pages separate result sets collides with that — a
+user calling `nextset()` to skip to the next statement's output would land on page 2 of the
+same query. Pagination is one logical result set delivered in chunks, not multiple result
+sets.
+
+**C. Drain inside the client (`databases_query` returns a merged full list).** Rejected: it
+would force eager draining always, making lazy streaming impossible, and would push the
+pagination loop below the layer (the `Cursor`) that needs to control laziness.
+
+**D. Expose `page_size` as a user knob.** Rejected for v1: the ≤100 cap and the
+`yield_per`/`page_size` decoupling are Notion-transport details. `yield_per` is the
+SQLAlchemy-idiomatic logical knob; leaking `page_size` invites users to set values >100 that
+silently clamp.
+
+## Consequences
+
+- **Fixes the latent silent-row-drop** for joins and two-phase DML against paginated results,
+  as a side effect of drain-all-by-default — independently of whether anyone uses streaming.
+- **`ResultSet` is no longer a frozen `list[tuple]`** — it holds page-fetch state. Its
+  equality/`description` contracts and the DBAPI `description` are otherwise unchanged.
+- **New user-visible API:** `execution_options(stream_results=True)` / `yield_per=N` on the
+  `Select` read path; `__iter__`/`fetchone`/`fetchmany` stream, `all()`/`fetchall()`
+  materialize-by-draining (documented, not blocked).
+- **Adopts the centralized error translator on the lazy path**, nudging toward retiring the
+  inline `raise ... from ne` in `execute()` (pre-existing tech debt; separate cleanup).
+- **Out of scope (named boundaries):** GET-style paginated endpoints (body vs `query_params`
+  injection); `search`/`_get_by_title` pagination; `CursorResult.partitions(n)`; real Notion
+  integration and the relation-property `has_more` truncation
+  ([ADR-0007](./0007-join-dangling-fk-propagation.md)).

--- a/docs/adr/0010-streaming-result-token-pagination.md
+++ b/docs/adr/0010-streaming-result-token-pagination.md
@@ -125,7 +125,22 @@ silently clamp.
   `Select` read path; `__iter__`/`fetchone`/`fetchmany` stream, `all()`/`fetchall()`
   materialize-by-draining (documented, not blocked).
 - **Adopts the centralized error translator on the lazy path**, nudging toward retiring the
-  inline `raise ... from ne` in `execute()` (pre-existing tech debt; separate cleanup).
+  inline `raise ... from ne` in `execute()` (pre-existing tech debt; separate cleanup). The lazy
+  green generalized `_translate_notion_error` from `NotionError` to any `Exception`
+  (KeyError/ValueError/NotionError + unknown-type fallback), which also fixed a latent orphaned
+  fallback that left unrecognised `NotionError` codes unmapped.
+- **Pagination is an `execute`-only concern.** `executemany` stays the non-paginated bulk-write
+  path — one client call per parameter set, no `next_cursor` walk, skip-and-continue error
+  handling — and returns no streamable result set (per DBAPI 2.0, `executemany` is not for
+  row-returning operations). Neither drain-all nor streaming applies to it. This is a permanent
+  boundary by design, not a deferred slice.
+- **Realized seam shape.** The page-fetch seam shipped as a standalone `PageIterator`
+  (`notiondbapi/page_iterator.py`) owned by the `Cursor` as `_page_iter`, with
+  `ResultSet.extend_from_json(page)` appending each page's rows — rather than a `_fetch_next`
+  closure internal to `ResultSet` as sketched in the Decision. The decision content (one streaming
+  `ResultSet`, `Cursor`-owned seam, first page eager, `page_size` injected into the body) is
+  unchanged; only the object boundary moved. `PageIterator._page_size` now carries the clamped
+  size; `fetchone` pulls on buffer-drain and `fetchall` drives the pull to completion.
 - **Out of scope (named boundaries):** GET-style paginated endpoints (body vs `query_params`
   injection); `search`/`_get_by_title` pagination; `CursorResult.partitions(n)`; real Notion
   integration and the relation-property `has_more` truncation

--- a/docs/adr/0010-streaming-result-token-pagination.md
+++ b/docs/adr/0010-streaming-result-token-pagination.md
@@ -114,6 +114,13 @@ silently clamp.
   as a side effect of drain-all-by-default — independently of whether anyone uses streaming.
 - **`ResultSet` is no longer a frozen `list[tuple]`** — it holds page-fetch state. Its
   equality/`description` contracts and the DBAPI `description` are otherwise unchanged.
+- **Paginated `execute()` is atomic in drain-all mode.** The cursor drains every page into a
+  *local* `ResultSet` and only publishes it (`_reset_results()` + append) after the full token
+  walk succeeds. A failure on any page — a `NotionError` translated to a DBAPI error, or a
+  malformed page (`has_more=True` with `next_cursor=None`) surfaced as `DatabaseError` — leaves
+  the cursor's prior result state untouched: callers never observe a torn read presented as
+  complete. (Lazy streaming relaxes this by construction — see Slice 5 mid-stream error
+  propagation.)
 - **New user-visible API:** `execution_options(stream_results=True)` / `yield_per=N` on the
   `Select` read path; `__iter__`/`fetchone`/`fetchmany` stream, `all()`/`fetchall()`
   materialize-by-draining (documented, not blocked).

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ autoapi/index
 
 changelog.md
 contributing.md
+releasing.md
 ```
 
 ```{toctree}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,122 @@
+# Cutting a release
+
+This guide describes how to publish a new release of **normlite** using the
+project's CD pipeline. The pipeline is fully automated through GitHub Actions:
+you trigger one workflow, review the pull request it opens, and merge it. Tagging
+and documentation deployment happen on their own.
+
+## What the pipeline does
+
+Releases are driven by [Commitizen](https://commitizen-tools.github.io/commitizen/)
+on top of [conventional commits](https://www.conventionalcommits.org/). The
+version is derived from the commit history — you never edit the version number by
+hand.
+
+Relevant `pyproject.toml` configuration:
+
+```toml
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "$version"          # tags are bare, e.g. 0.11.0 (no "v" prefix)
+version_scheme = "pep440"
+version_provider = "uv"
+update_changelog_on_bump = true
+major_version_zero = true        # breaking changes bump the minor while 0.x
+```
+
+Three workflows cooperate:
+
+| Workflow | File | Trigger | Role |
+|----------|------|---------|------|
+| **CI** | `.github/workflows/ci.yml` | push / PR to `main` | Quality gate: tests, coverage, docs build |
+| **Release** | `.github/workflows/release.yml` | manual (`workflow_dispatch`) | Bumps version, writes changelog, opens the release PR |
+| **Tag and Deploy** | `.github/workflows/tag-and-deploy.yml` | merge of a `release/v*` PR | Re-points the tag to the merge commit, deploys docs |
+
+> **Note:** the pipeline does **not** publish to PyPI. It produces a git tag, an
+> updated `CHANGELOG`, and a deployed documentation site. Distribution to a package
+> index, if needed, is a separate manual step.
+
+## Prerequisites
+
+- Everything you want in the release is **merged into `main`** as
+  [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`,
+  `docs:`, `refactor:`, etc.). The commit types determine the version bump.
+- CI is green on `main`.
+- You have permission to run workflows in the repository.
+
+While the project is on `0.x` (`major_version_zero = true`):
+
+- `fix:` → patch bump (e.g. `0.10.0` → `0.10.1`)
+- `feat:` → minor bump (e.g. `0.10.0` → `0.11.0`)
+- A breaking change (`feat!:` or a `BREAKING CHANGE:` footer) → **minor** bump,
+  not major, until the project reaches `1.0.0`.
+
+If you want to preview the next version locally before triggering anything:
+
+```bash
+uv run cz bump --dry-run --yes
+```
+
+## Step 1 — Trigger the Release workflow
+
+1. Go to the repository's **Actions** tab on GitHub.
+2. Select the **Release** workflow.
+3. Click **Run workflow**, making sure the branch is **`main`** (the workflow
+   aborts if triggered from any other branch).
+4. Run it.
+
+The workflow then, automatically:
+
+1. Verifies it is running from `main`.
+2. Computes the next version from the commit history (`cz bump --dry-run`).
+3. Creates a `release/v<version>` branch.
+4. Runs `cz bump --yes`, which updates the version in `pyproject.toml`, updates
+   the changelog, and creates the version tag locally.
+5. Pushes the branch and tag.
+6. Opens a pull request titled `release: v<version>` against `main`.
+
+## Step 2 — Review the release PR
+
+Open the pull request the workflow created and check:
+
+- The **version bump** in `pyproject.toml` is what you expected.
+- The **changelog** entries are correct and readable.
+- CI on the PR is green.
+
+If something is wrong (e.g. a commit was mis-typed and produced the wrong bump),
+**close the PR, delete the `release/v<version>` branch and tag**, fix the commit
+history on `main`, and re-run the Release workflow.
+
+## Step 3 — Merge the release PR
+
+Merging the PR into `main` triggers **Tag and Deploy**, which:
+
+1. Re-points the version tag to the merge commit (so the tag lands on `main`,
+   not on the now-merged release branch).
+2. Builds the Sphinx documentation.
+3. Deploys it to GitHub Pages (the `github-pages` environment).
+
+Once this workflow finishes, the release is complete: the tag exists on `main`
+and the published documentation reflects the new version.
+
+## Troubleshooting
+
+- **Release workflow aborts immediately** — it was not triggered from `main`.
+  Re-run with `main` selected.
+- **"No commits found" / no version bump** — there are no release-worthy
+  conventional commits since the last tag. Ensure your changes use `feat:` /
+  `fix:` (etc.) commit messages.
+- **Wrong version computed** — a commit message used the wrong type. Verify with
+  `uv run cz bump --dry-run --yes`, fix the history on `main`, and re-run.
+- **Tag/branch left over from an aborted attempt** — delete the remote branch
+  and tag before retrying:
+
+  ```bash
+  git push origin --delete release/v<version>
+  git push origin :refs/tags/<version>
+  ```
+
+- **Docs didn't update after merge** — check the **Tag and Deploy** run; the
+  `deploy-docs` job deploys to the `github-pages` environment. A standalone
+  docs-only deploy is also available via the manual **Build and Deploy
+  Documentation** workflow (`.github/workflows/docs.yml`).

--- a/plans/streaming-token-pagination-teaching-slices.md
+++ b/plans/streaming-token-pagination-teaching-slices.md
@@ -1,0 +1,102 @@
+# Teaching Slices — Streaming Result over Token Pagination
+
+**Source design:** [ADR-0010](../docs/adr/0010-streaming-result-token-pagination.md) ·
+CONTEXT.md → "Pagination"
+**Status:** Approved (not published to tracker)
+**Difficulty mix:** 2 Guided · 2 Stretch · 1 Challenge
+
+End-to-end vertical slices, ordered by dependency. Each fits 3–10 TDD iterations and is
+independently verifiable. Ships against in-memory clients only (no real Notion integration yet).
+
+```
+Slice 1 ──▶ Slice 2 ──▶ Slice 3 ──┬──▶ Slice 4
+                                   └──▶ Slice 5
+```
+Slices 4 and 5 depend only on 3 and may proceed in parallel.
+
+---
+
+## Slice 1 — Fake client paginates `databases_query`
+
+- **Learning Mode:** Guided · **Difficulty:** Guided · **Blocked by:** none
+- **User stories:** substrate — drain-all becomes testable end-to-end against the fake.
+- **Learning Objective:** Implement producer-side token/keyset pagination — slice a result list
+  by an opaque cursor and report continuation honestly.
+- **Concepts Practiced:** `page_size`/`start_cursor` handling, `has_more`/`next_cursor` shape,
+  opaque offset-token encode/decode, default `page_size=100`, paginate *after* filter+sort.
+- **Failure Modes to Watch:** off-by-one on the last page (`has_more` true when exactly drained);
+  `next_cursor` set while `has_more` false; leaking a bare integer token; paginating before
+  filter+sort.
+- **Suggested First Test:** 3 matching pages, `page_size=2` → response 1: 2 results,
+  `has_more=True`, non-null `next_cursor`; response 2 (with that cursor): 1 result,
+  `has_more=False`, `next_cursor=None`; union equals all 3 rows in order.
+
+## Slice 2 — `ResultSet` page-fetch seam + drain-all in `Cursor`
+
+- **Learning Mode:** Guided · **Difficulty:** Stretch · **Blocked by:** Slice 1
+- **User stories:** correctness floor — every existing caller gets all pages for free.
+- **Learning Objective:** Turn a frozen `list[tuple]` into a result that owns its continuation
+  state; drive the drain loop from the layer holding the client.
+- **Concepts Practiced:** `_fetch_next(start_cursor)` closure built by `Cursor`; body-injection of
+  `start_cursor`/`page_size` into `databases.query`; first-page-eager (description + error
+  translation); `next_cursor`/`has_more`/`exhausted` state; `nextset()` stays orthogonal.
+- **Failure Modes to Watch:** page-per-`ResultSet` (corrupts `nextset()`); mutating shared
+  `payload` instead of a per-fetch copy; infinite loop when `has_more` true but `next_cursor`
+  null; breaking `executemany` multi-result-set semantics.
+- **Suggested First Test:** 5 matching pages, internal `page_size=2`, `execute(query)` then
+  `fetchall()` returns all 5 in order; `rowcount == 5`. Regression: `executemany` still yields one
+  result set per param batch.
+
+## Slice 3 — Opt-in lazy fetching at the DBAPI level (`stream_results`/`yield_per`)
+
+- **Learning Mode:** Guided · **Difficulty:** Challenge · **Blocked by:** Slice 2
+- **User stories:** iterate large results with bounded memory.
+- **Learning Objective:** Make fetching demand-driven and prove it by observation (client not
+  called until the buffer drains); honor the deferred-`rowcount` contract.
+- **Concepts Practiced:** `ExecutionOptions` keys `stream_results`/`yield_per` (`yield_per` implies
+  `stream_results`); `page_size = min(yield_per or 100, 100)`; `yield_per > 100` pulls multiple
+  pages per batch; `rowcount == -1` until `exhausted`.
+- **Failure Modes to Watch:** eagerly draining anyway (test must count client calls, not totals);
+  buffered-length as `rowcount` mid-stream; forgetting `yield_per` implies `stream_results`;
+  wrong `page_size` clamp when `yield_per > 100`.
+- **Suggested First Test:** Call-counting fake, `yield_per=2` over 5 rows: after `execute()` the
+  client was called once; `rowcount == -1`; fetching row 3 triggers a second call; after
+  exhaustion `rowcount == 5`.
+
+## Slice 4 — Select-only gating + `CursorResult` streaming consumption
+
+- **Learning Mode:** Solo · **Difficulty:** Stretch · **Blocked by:** Slice 3
+- **User stories:** streaming never corrupts a mutation or join.
+- **Learning Objective:** Gate a cross-cutting option to exactly one execution path; expose
+  streaming through the high-level façade.
+- **Concepts Practiced:** gate streaming to the row-returning `Select` path (mutations / join
+  phase-1 / reflection force drain-all even with `stream_results=True` on the connection);
+  `CursorResult.__iter__`/`fetchone`/`fetchmany` stream, `all()`/`fetchall()` materialize.
+- **Failure Modes to Watch:** gating on the raw option instead of "is this a user-facing Select"
+  (a `Delete` on a streaming connection silently streams phase 1); `all()` short-circuiting the
+  drain; `one()`/`first()` not stopping early.
+- **Suggested First Test:** On a `stream_results=True` connection, a two-phase `Delete` still
+  drains all phase-1 pages and reports accurate `rowcount`; separately,
+  `conn.execute(select).fetchmany(2)` returns 2 `Row`s and leaves the rest unfetched.
+
+## Slice 5 — Mid-stream error propagation
+
+- **Learning Mode:** Solo · **Difficulty:** Stretch · **Blocked by:** Slice 3
+- **User stories:** a failed page surfaces honestly, not as silent truncation.
+- **Learning Objective:** Route a failure occurring *after* `execute()` through the centralized
+  translator and propagate it at the iteration boundary.
+- **Concepts Practiced:** `_fetch_next` using `_translate_notion_error`; propagate (no
+  skip-and-continue); already-yielded rows stay yielded.
+- **Failure Modes to Watch:** copying `executemany`'s skip-and-continue (unreachable later pages);
+  swallowing into an empty result; raising raw `NotionError` instead of the mapped DBAPI class.
+- **Suggested First Test:** Fake injects `rate_limited` on page 2; iterating yields page-1 rows,
+  then raises `OperationalError` (with `NotionError` as `__cause__`) crossing into page 2.
+
+---
+
+## Out of scope (named boundaries, per ADR-0010)
+
+- GET-style paginated endpoints (`query_params` injection vs body).
+- `search` / `_get_by_title` pagination (stay single-page).
+- `CursorResult.partitions(n)`.
+- Real Notion integration and relation-property `has_more` truncation (ADR-0007).

--- a/src/normlite/engine/base.py
+++ b/src/normlite/engine/base.py
@@ -130,8 +130,9 @@ class Connection:
         isolation_level: IsolationLevel = ..., # type: ignore
         implicit_returning: bool = False,
         preserve_rowcount: bool = False,    
-        preserve_rowid: bool = False,        
-        page_size: int = 100,
+        preserve_rowid: bool = False,     
+        stream_results: bool = False,
+        yield_per: Optional[int] = None,
         **opts: Any
     ) -> Connection:
         ...
@@ -267,7 +268,9 @@ class Connection:
         self._engine.do_execute(
             context._get_exec_cursor(), 
             context.operation, 
-            context.parameters
+            context.parameters,
+            streamable=elem.is_select,      # stream_results, yield_per options considered for SELECT statements only
+            execution_options=context.execution_options
         )
 
     
@@ -554,7 +557,8 @@ class Engine:
         implicit_returning: bool = False,
         preserve_rowcount: bool = False,
         preserve_rowid: bool = False,
-        page_size: int = 100,            
+        stream_results: bool = False,
+        yield_per: Optional[int] = None,
         **opts: Any
     ) -> Engine:
         ...
@@ -985,9 +989,27 @@ class Engine:
             cursor: DBAPICursor,
             operation: dict,
             parameters: dict,
+            *,
+            streamable: Optional[bool] = False,
+            execution_options: Optional[ExecutionOptions] = None
     ) -> None:
         """Execute an operation on the supplied DBAPI cursor."""
-        cursor.execute(operation, parameters)
+
+        # default behavior: do_execute is **not** streamable
+        stream_results = False
+        yield_per = None
+
+        if streamable:
+            # explicitly requested results to be streamed
+            stream_results = execution_options.get("stream_results") if execution_options else None
+            yield_per = execution_options.get("yield_per") if execution_options else None
+        
+        cursor.execute(
+            operation, 
+            parameters, 
+            stream_results=stream_results,
+            yield_per=yield_per
+        )
 
     def do_executemany(
             self,

--- a/src/normlite/engine/interfaces.py
+++ b/src/normlite/engine/interfaces.py
@@ -90,6 +90,28 @@ class ExecutionOptions(TypedDict, total=False):
     .. versionadded:: 0.9.0
     """
 
+    stream_results: Optional[bool]
+    """Indicate that results should be “streamed” and not pre-buffered, if possible.
+    
+    The usage is usually combined with setting a fixed number of rows to be fetched in batches, 
+    to allow for efficient iteration of database rows while at the same time not loading 
+    all result rows into memory at once.
+
+    .. seealso::
+
+        See :attr:`yield_per` for more information on how to set the size of batches to be fetched.
+
+    .. versionadded:: 0.11.0
+    """
+
+    yield_per: Optional[int]
+    """Configure the row-fetching strategy to fetch yield_per rows at a time.
+    
+    The :attr:`yield_per` option simultaneously set the :attr:`stream_results` to ``True``.
+
+    .. versionadded:: 0.11.0
+    """
+
 _CoreSingleExecuteParams = Mapping[str, Any]
 _CoreMultiExecuteParams = Sequence[_CoreSingleExecuteParams]
 _CoreAnyExecuteParams = Union[

--- a/src/normlite/notion_sdk/client.py
+++ b/src/normlite/notion_sdk/client.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
-import pdb
 from typing import List, Optional, Self, Set, Type
 from types import TracebackType
 from abc import ABC, abstractmethod
@@ -108,12 +107,49 @@ class NotionError(Exception):
             f"message={self.message!r})"
         )
 
+# Namespace UUID used to generate deterministic UUIDs
+# Using the standard DNS namespace as a base
+NAMESPACE_UUID = uuid.NAMESPACE_DNS
+
+def encode_cursor(index: int) -> str:
+    """Encodes an integer index into a valid, opaque UUID4 string."""
+    # Step 1: Create a deterministic base UUID from the index to ensure uniqueness
+    base_uuid = uuid.uuid5(NAMESPACE_UUID, f"cursor-{index}")
+    
+    # Step 2: Extract the raw bytes
+    uuid_bytes = bytearray(base_uuid.bytes)
+    
+    # Step 3: Embed the integer into the last 4 bytes (supports up to 4.2 billion)
+    # This keeps the integer safe inside the node payload of the UUID
+    uuid_bytes[12:16] = index.to_bytes(4, byteorder='big')
+    
+    # Step 4: Enforce RFC 4122 UUID Version 4 variant and version bits
+    uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x40  # Set version to 4
+    uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80  # Set variant to RFC 4122
+    
+    return str(uuid.UUID(bytes=bytes(uuid_bytes)))
+
+def decode_cursor(cursor_str: str) -> int:
+    """Decodes the opaque UUID4 string back into the original integer index."""
+    try:
+        # Convert string back to UUID object
+        parsed_uuid = uuid.UUID(cursor_str)
+        uuid_bytes = parsed_uuid.bytes
+        
+        # Extract the integer from the last 4 bytes of the payload
+        index = int.from_bytes(uuid_bytes[12:16], byteorder='big')
+        return index
+    except ValueError as e:
+        raise ValueError(f"Invalid or corrupted cursor string: {cursor_str}") from e
+
 class AbstractNotionClient(ABC):
     """Base class for a Notion API client.
 
     """
     allowed_operations: Set[str] = set()
     """The set of Notion API calls."""
+
+    NOTION_MAX_PAGE_SIZE = 100
 
     def __init__(self):
         self._ischema_page_id = None
@@ -1098,6 +1134,8 @@ class InMemoryNotionClient(AbstractNotionClient):
 
         if not self._store_len():
             return query_result_object
+        
+        payload = payload or {}
 
         database_id = path_params.get('database_id') if path_params else None
         if database_id is None:
@@ -1166,15 +1204,29 @@ class InMemoryNotionClient(AbstractNotionClient):
                 pages.sort(key=sort_key, reverse=reverse)
 
         # --------------------
+        # Pagination
+        # --------------------
+        # recompute the view at every request
+        requested_page_size = payload.get("page_size") or InMemoryNotionClient.NOTION_MAX_PAGE_SIZE
+        page_size = min(requested_page_size, InMemoryNotionClient.NOTION_MAX_PAGE_SIZE)
+        start_cursor = payload.get("start_cursor")
+        offset = decode_cursor(start_cursor) if start_cursor is not None else 0
+        end = offset + page_size
+
+        # --------------------
         # Projection phase
         # --------------------
-        for page in pages:
+        for page in pages[offset:end]:
             if filter_properties:
                 query_results.append(
                     self._filter_properties(page, filter_properties)
                 )
             else:
                 query_results.append(page)
+
+        if end < len(pages):
+            query_result_object["has_more"] = True
+            query_result_object["next_cursor"] = encode_cursor(end)
 
         return query_result_object
 

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -17,12 +17,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
-from operator import itemgetter
-from typing import Any, Callable, Dict, Iterator, List, Literal, NoReturn, Optional, Self, Sequence, Tuple, Type, TypeAlias, Union
+from typing import Any, Callable, Dict, Iterator, List, Literal, NoReturn, Optional, Self, Sequence, Type, TypeAlias, Union
 from itertools import islice
 import uuid
-from flask.testing import FlaskClient
-
 
 from normlite._constants import SpecialColumns
 from normlite.notion_sdk.client import AbstractNotionClient, NotionError
@@ -620,7 +617,17 @@ class Cursor:
 
         n = self.arraysize if size is None else size
 
-        return list(islice(rs, n))
+        result = list(islice(rs, n))
+        if len(result) < n:
+            # the current result set contains less than the requested n rows
+            # try to trigger a new page fetch and retrieve as many rows as possible
+            for _ in range(n - len(result)):
+                row = self.fetchone()
+                if row is None:
+                    break
+                result.append(row)
+
+        return result
     
     def execute(
         self, 
@@ -901,6 +908,11 @@ class Cursor:
             )
 
         for rs in self._result_sets:
+            if rs is self._current_result_set:
+                # the current result set may be associated to a paginated result to be drained
+                while self._page_iter is not None and not self._page_iter.exhausted:
+                    rs.extend_from_json(next(self._page_iter))
+
             yield from rs
     
     def close(self) -> None:

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -693,12 +693,17 @@ class Cursor:
                 'Cannot fetch rows or execute operations on a closed cursor'
             )
 
+        page_size = min(yield_per, 100) if yield_per is not None else None
+
         def page_fetcher(start_cursor: Optional[str] = None) -> dict:
             payload = parameters.get("payload")
+            if page_size is not None:
+                payload = {**(payload or {}), "page_size": page_size}
+
             if start_cursor is not None:
                 # per-fetch copy of payload
                 # IMPORTANT: payload may be None, so update it in a None-safe way
-                payload = {**payload, "start_cursor": start_cursor}
+                payload = {**(payload or {}), "start_cursor": start_cursor}
 
             return self._client(
                 operation['endpoint'],
@@ -712,7 +717,7 @@ class Cursor:
         is_streaming = stream_results or yield_per is not None
         
         try:
-            self._page_iter = PageIterator(page_fetcher=page_fetcher, page_size=yield_per)
+            self._page_iter = PageIterator(page_fetcher=page_fetcher, page_size=page_size)
             
             # fetch the first page
             # construct a temporary result set to handle mid-drain error translation:

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -26,6 +26,7 @@ from flask.testing import FlaskClient
 
 from normlite._constants import SpecialColumns
 from normlite.notion_sdk.client import AbstractNotionClient, NotionError
+from normlite.notiondbapi.page_iterator import PageIterator
 from normlite.notiondbapi.resultset import ResultSet
 
 DBAPIParamStyle = Literal[
@@ -435,7 +436,7 @@ class Cursor:
                 or no call was issued yet.
 
         Yields:
-            Iterator[Iterable[tuple]]: The next row in the result set.
+            Iterator[tuple]: The next row in the result set.
 
         .. versionchanged:: 0.9.0
             This version uses the new redesigned iterator based :class:`normlite.notiondbapi.resultset.ResultSet`
@@ -652,20 +653,44 @@ class Cursor:
                 'Cannot fetch rows or execute operations on a closed cursor'
             )
 
-        object_ = {}
-        try:
-            object_ = self._client(
+        def page_fetcher(start_cursor: Optional[str] = None) -> dict:
+            payload = parameters.get("payload")
+            if start_cursor is not None:
+                # per-fetch copy of payload
+                # IMPORTANT: payload may be None, so update it in a None-safe way
+                payload = {**payload, "start_cursor": start_cursor}
+
+            return self._client(
                 operation['endpoint'],
                 operation['request'],
                 parameters.get('path_params'),
                 parameters.get('query_params'),
-                parameters.get('payload'),
-            )
+                payload,
+            ) 
+
+        object_ = {}
+        try:
+            page_iter = PageIterator(page_fetcher=page_fetcher)
+            
+            # fetch the first page
+            # construct a temporary result set to handle mid-drain error translation:
+            # all-or-nothing result
+            object_ = next(page_iter)
+            rs = ResultSet.from_json(self._description, notion_obj=object_)           
+           
+            # retrieve remaining pages using the specified page size
+            for object_ in page_iter:
+                rs.extend_from_json(object_)
+
         except KeyError as ke:
             # Programming error in the DBAPI usage
             raise InterfaceError(
                 f"Missing required key in operation or parameters: {ke.args[0]}"
             ) from ke
+        
+        except ValueError as ve:
+            # --- A malformed Notion object with has_more = True and next_cursor = None
+            raise DatabaseError from ve
 
         except NotionError as ne:
             # --- Database object does not exist -----------------------------
@@ -698,7 +723,7 @@ class Cursor:
             ) from ne
         
         self._reset_results()
-        self._append_result_set(object_)
+        self._result_sets.append(rs)  
         return self
     
     def executemany(self, operation: dict, parameters: Sequence[DBAPIExecuteParameters]) -> Self:

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -216,6 +216,12 @@ class Cursor:
         .. versionadded:: 0.9.0
         """
 
+        self._page_iter: PageIterator = None
+        """Iterator for handling Notion paginated results.
+        
+        .. versionadded:: 0.11.0
+        """
+
     @property
     def errorhandler(self) -> DBAPIErrorHandlerType:
         return self._errorhandler or self._connection.errorhandler
@@ -284,7 +290,7 @@ class Cursor:
         .. important::
             This version supports non paginated results. Thus, the :attr:`rowcount` is _always_
             equal to the rows contained in the current result set.
-            In future versions supporting paginated results, the :attr:`rowcount` will be -1 
+            It supports result streaming (paginated results): the :attr:`rowcount` remains -1 
             _until all pages have been retrieved_. Once this condition is fulfilled, :attr:`rowcount`
             will provide the sum of all retrieved pages.
             For example, let's assume the query being executed returns 100 rows. Notion returns batches
@@ -296,10 +302,17 @@ class Cursor:
                  on the cursor or the rowcount of the last operation cannot be 
                  determined by the interface.
 
+        .. versionchanged:: 0.11.0
+            This version adds support for row counting when result streaming (lazy page fetching) is active.
+        
         .. versionchanged:: 0.9.0
             This version adds support for row counting in case of multiple result sets
         """
         if not self._result_sets:
+            return -1
+        
+        if self._page_iter is not None and not self._page_iter.exhausted:
+            # result streaming ongoing: total is unknown until every page is pulled
             return -1
         
         # sum of all result sets in the cursor
@@ -499,8 +512,25 @@ class Cursor:
 
         try:
             return next(rs)
+        
         except StopIteration:
-            return None
+            # buffer exhausted, try fetching next page
+            if self._page_iter is None or self._page_iter.exhausted:
+                # no pages to retrieve
+                return None
+            
+            # fetch next page and extend current result set
+            object_ = next(self._page_iter)
+            self._current_result_set.extend_from_json(object_)
+            try:
+                return next(self._current_result_set)  
+            except StopIteration:
+                return None
+        
+        except Exception as e:
+            # something went wrong during fetching, re-raise as DBAPI error
+            _, exc = self._translate_notion_error(e)
+            raise exc
 
     def fetchall(self) -> List[tuple]:
         """Fetch all rows of this query result. 
@@ -542,6 +572,9 @@ class Cursor:
                 'Hint: .rowcount is 0 if .execute*() did not produce any result set '
                 'or -1 if no call was issued yet.' 
             )
+
+        while self._page_iter is not None and not self._page_iter.exhausted:
+            rs.extend_from_json(next(self._page_iter))
 
         return list(rs)
     
@@ -589,7 +622,14 @@ class Cursor:
 
         return list(islice(rs, n))
     
-    def execute(self, operation: dict, parameters: DBAPIExecuteParameters) -> Self:
+    def execute(
+        self, 
+        operation: dict, 
+        parameters: DBAPIExecuteParameters,
+        *,
+        stream_results=False,
+        yield_per=None
+    ) -> Self:
         """Prepare and execute a database operation (query or command).
 
         Parameters may be provided as a mapping and will be bound to variables in the operation.
@@ -669,17 +709,24 @@ class Cursor:
             ) 
 
         object_ = {}
+        is_streaming = stream_results or yield_per is not None
+        
         try:
-            page_iter = PageIterator(page_fetcher=page_fetcher)
+            self._page_iter = PageIterator(page_fetcher=page_fetcher, page_size=yield_per)
             
             # fetch the first page
             # construct a temporary result set to handle mid-drain error translation:
             # all-or-nothing result
-            object_ = next(page_iter)
-            rs = ResultSet.from_json(self._description, notion_obj=object_)           
+            object_ = next(self._page_iter)
+            rs = ResultSet.from_json(self._description, notion_obj=object_)     
+            if is_streaming:
+                # fetch pages lazily using the yield_per as page_size 
+                self._reset_results()
+                self._result_sets.append(rs)  
+                return self
            
-            # retrieve remaining pages using the specified page size
-            for object_ in page_iter:
+            # retrieve remaining pages eargerly
+            for object_ in self._page_iter:
                 rs.extend_from_json(object_)
 
         except KeyError as ke:
@@ -690,7 +737,7 @@ class Cursor:
         
         except ValueError as ve:
             # --- A malformed Notion object with has_more = True and next_cursor = None
-            raise DatabaseError from ve
+            raise DatabaseError() from ve
 
         except NotionError as ne:
             # --- Database object does not exist -----------------------------
@@ -767,8 +814,8 @@ class Cursor:
         
         return self
     
-    def _translate_notion_error(self, ne: NotionError) -> tuple[Type[Error], Error]:
-        """Map a NotionError to a DBAPI 2.0 (errorclass, errorvalue) pair.
+    def _translate_notion_error(self, e: Exception) -> tuple[Type[Error], Error]:
+        """Map an exception to a DBAPI 2.0 (errorclass, errorvalue) pair.
 
         Centralises the wrapping logic previously duplicated across
         .execute() and .executemany(). Returns the pair rather than
@@ -777,30 +824,48 @@ class Cursor:
         The returned errorvalue has ``__cause__`` set to the original
         NotionError, matching what ``raise X(...) from ne`` would produce.
         """
-        # --- Database object does not exist -----------------------------
-        if ne.code == "object_not_found":
-            exc = ProgrammingError(f'NotionError("Object not found: {ne}') 
+        if isinstance(e, KeyError):
+            exc = InterfaceError(
+                f"Missing required key in operation or parameters: {e.args[0]}"
+            )
 
-        # --- Authentication / authorization -----------------------------
-        elif ne.code in {"unauthorized", "forbidden"}:
-            exc = OperationalError(f'Authentication/authorization failure: {ne}')
+        elif isinstance(e, ValueError):
+            exc = DatabaseError(
+                "Received malformed object result with has_more True and "
+                "start_cursor None."
+            )
 
-        # --- Rate limiting / availability -------------------------------
-        elif ne.code in {"rate_limited", "service_unavailable"}:
-            exc = OperationalError(f'Backend temporarily unavailable: {ne}')
+        elif isinstance(e, NotionError):
+            # --- Database object does not exist -----------------------------
+            if e.code == "object_not_found":
+                exc = ProgrammingError(f'NotionError("Object not found: {e}')
 
-        # --- Malformed request / client misuse --------------------------
-        elif ne.code in {"invalid_request", "validation_error"}:
-            exc = InterfaceError(f'Invalid request sent to backend: {ne}')
+            # --- Authentication / authorization -----------------------------
+            elif e.code in {"unauthorized", "forbidden"}:
+                exc = OperationalError(f'Authentication/authorization failure: {e}')
+
+            # --- Rate limiting / availability -------------------------------
+            elif e.code in {"rate_limited", "service_unavailable"}:
+                exc = OperationalError(f'Backend temporarily unavailable: {e}')
+
+            # --- Malformed request / client misuse --------------------------
+            elif e.code in {"invalid_request", "validation_error"}:
+                exc = InterfaceError(f'Invalid request sent to backend: {e}')
+
+            else:
+                # --- Fallback: NotionError with an unrecognised code --------
+                exc = DatabaseError(
+                    f'Unhandled NotionError("{type(self._client).__name__}"): {e}'
+                )
 
         else:
-        # --- Fallback: backend rejected operation -----------------------
+            # --- Fallback: unknown exception type ---------------------------
             exc = DatabaseError(
-                f'Unhandled NotionError("{self._client.__class__.__name__}"): {ne}'
+                f'Unhandled exception ({type(e).__name__}): {e}'
             )
 
         # Mirror `raise X(...) from ne` semantics manually
-        exc.__cause__ = ne
+        exc.__cause__ = e
         exc.__suppress_context__ = True
         return type(exc), exc
             

--- a/src/normlite/notiondbapi/dbapi2.py
+++ b/src/normlite/notiondbapi/dbapi2.py
@@ -470,6 +470,36 @@ class Cursor:
             )
 
         return self
+    
+    def _try_fetch_next(self) -> Optional[tuple]:
+        if self._page_iter is None or self._page_iter.exhausted:
+            # no pages to retrieve
+            return None
+        
+        # fetch next page and extend current result set
+        try:
+            object_ = next(self._page_iter)
+            self._current_result_set.extend_from_json(object_)
+            return next(self._current_result_set)  
+        
+        except StopIteration:
+            return None
+        
+        except Exception as e:
+            # something went wrong during fetching, re-raise as DBAPI error
+            _, exc = self._translate_notion_error(e)
+            raise exc
+
+    def _drain_pages(self, rs: ResultSet) -> None:
+        """Helper to mutate the passed result set by draining all the remaining pages."""
+        try:
+            while self._page_iter is not None and not self._page_iter.exhausted:
+                rs.extend_from_json(next(self._page_iter))
+
+        except Exception as e:
+            # something went wrong during fetching, re-raise as DBAPI error
+            _, exc = self._translate_notion_error(e)
+            raise exc
 
     def fetchone(self) -> Optional[tuple]:
         """Fetch the next row of a query result set.
@@ -512,17 +542,7 @@ class Cursor:
         
         except StopIteration:
             # buffer exhausted, try fetching next page
-            if self._page_iter is None or self._page_iter.exhausted:
-                # no pages to retrieve
-                return None
-            
-            # fetch next page and extend current result set
-            object_ = next(self._page_iter)
-            self._current_result_set.extend_from_json(object_)
-            try:
-                return next(self._current_result_set)  
-            except StopIteration:
-                return None
+            return self._try_fetch_next()
         
         except Exception as e:
             # something went wrong during fetching, re-raise as DBAPI error
@@ -570,9 +590,7 @@ class Cursor:
                 'or -1 if no call was issued yet.' 
             )
 
-        while self._page_iter is not None and not self._page_iter.exhausted:
-            rs.extend_from_json(next(self._page_iter))
-
+        self._drain_pages(rs)
         return list(rs)
     
     def fetchmany(self, size: Optional[int]=None) -> list[tuple]:
@@ -644,16 +662,21 @@ class Cursor:
         which the values are to be bound are known by name.
         In the current implementation, the parameter style implemented in the cursor is:
         `named`.
-        The :meth:`execute()` methods implements a return interface to enable concatenating 
+        The :meth:`execute` methods implements a return interface to enable concatenating 
         calls on :class:`Cursor` methods.
+        This method supports Notion paginated results. It sets an internal page iterator which is then used 
+        for lazy fetching of result pages.
 
         Important:
-            :meth:`.execute()` stores the executed command result(s) in the internal
-            result set. Always call this method prior to :meth:`BaseCursor.fetchone()` and :meth:`Cursor.fetchall()`,
+            :meth:`.execute` stores the executed command result(s) in the internal
+            result set. Always call this method prior to :meth:`Cursor.fetchone` and :meth:`Cursor.fetchall`,
             otherwise an :exc:`InterfaceError` error is raised. 
 
+        .. versionchanged:: 0.11.0
+            :meth:`Cursor.execute` now supports paginated results.
+
         .. versionchanged:: 0.7.0
-            :meth:`Cursor:execute()` now accepts operations with no parameters. This happens for ``CREATE TABLE`` DDL statements.
+            :meth:`Cursor:execute` now accepts operations with no parameters. This happens for ``CREATE TABLE`` DDL statements.
 
         .. versionchanged:: 0.5.0
             Calling this method on a closed cursor raises the :exc:`Error`.
@@ -689,6 +712,11 @@ class Cursor:
             Error: If the cursor is closed.
             InterfaceError: ``"properties"`` object not specified in parameters.
             InterfaceError: ``"parent"`` object not specified in parameters.
+            InterfaceError: If the backend returns an invalid request error.
+            ProgrammingError: If the backend returns an object not found error.
+            DatabaseError: If the backend returns a malformed result object.
+            OperationalError: If the backend flags an authorization failure or is temporarily unavailable (e.g. rate limited).
+
        
         Returns:
             Self: This :class:`Cursor` instance.
@@ -741,46 +769,11 @@ class Cursor:
             for object_ in self._page_iter:
                 rs.extend_from_json(object_)
 
-        except KeyError as ke:
-            # Programming error in the DBAPI usage
-            raise InterfaceError(
-                f"Missing required key in operation or parameters: {ke.args[0]}"
-            ) from ke
-        
-        except ValueError as ve:
-            # --- A malformed Notion object with has_more = True and next_cursor = None
-            raise DatabaseError() from ve
 
-        except NotionError as ne:
-            # --- Database object does not exist -----------------------------
-            if ne.code == "object_not_found":
-                raise ProgrammingError(
-                    f'NotionError("Object not found: {ne}'
-                ) from ne
+        except (KeyError, ValueError, NotionError) as e:
+            _, exc = self._translate_notion_error(e)
+            raise exc
 
-            # --- Authentication / authorization -----------------------------
-            if ne.code in {"unauthorized", "forbidden"}:
-                raise OperationalError(
-                    f'Authentication/authorization failure: {ne}'
-                ) from ne
-
-            # --- Rate limiting / availability -------------------------------
-            if ne.code in {"rate_limited", "service_unavailable"}:
-                raise OperationalError(
-                    f'Backend temporarily unavailable: {ne}'
-                ) from ne
-
-            # --- Malformed request / client misuse --------------------------
-            if ne.code in {"invalid_request", "validation_error"}:
-                raise InterfaceError(
-                    f'Invalid request sent to backend: {ne}'
-                ) from ne
-
-            # --- Fallback: backend rejected operation -----------------------
-            raise DatabaseError(
-                f'Unhandled NotionError("{self._client.__class__.__name__}"): {ne}'
-            ) from ne
-        
         self._reset_results()
         self._result_sets.append(rs)  
         return self
@@ -906,13 +899,11 @@ class Cursor:
             raise ProgrammingError(
                 "Cursor result set is empty. No execute*() call was issued."
             )
-
+        
         for rs in self._result_sets:
             if rs is self._current_result_set:
                 # the current result set may be associated to a paginated result to be drained
-                while self._page_iter is not None and not self._page_iter.exhausted:
-                    rs.extend_from_json(next(self._page_iter))
-
+                self._drain_pages(rs)
             yield from rs
     
     def close(self) -> None:

--- a/src/normlite/notiondbapi/page_iterator.py
+++ b/src/normlite/notiondbapi/page_iterator.py
@@ -1,0 +1,58 @@
+# notiondbapi/page_iterator.py
+# Copyright (C) 2026 Gianmarco Antonini
+#
+# This module is part of normlite and is released under the GNU Affero General Public License.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+
+class PageIterator:
+    _page_fetcher: callable
+    _page_size: int
+    _start_cursor: str
+    _exhausted: bool
+
+    def __init__(self, page_fetcher: callable, page_size=100):
+        self._page_fetcher = page_fetcher
+        self._page_size = page_size
+        self._exhausted = False
+        self._start_cursor = None
+
+    @property
+    def exhausted(self) -> bool:
+        return self._exhausted
+
+    def __iter__(self):
+        return self
+    
+    def __next__(self):
+        if self._exhausted:
+            raise StopIteration
+        
+        page = self._page_fetcher(self._start_cursor)
+        if page.get("has_more", False):
+            next_cursor = page.get("next_cursor")
+            if next_cursor is None:
+                # malformed result object: has_more=True but next_cursor=None
+                # set the exhausted flag anyway
+                self._exhausted = True
+                raise ValueError("Malformed Notion result object")
+            
+            self._start_cursor = next_cursor
+        
+        else:
+            self._exhausted = True
+
+        return page

--- a/src/normlite/notiondbapi/page_iterator.py
+++ b/src/normlite/notiondbapi/page_iterator.py
@@ -18,15 +18,18 @@
 
 
 
+from typing import Optional
+
+
 class PageIterator:
     _page_fetcher: callable
     _page_size: int
     _start_cursor: str
     _exhausted: bool
 
-    def __init__(self, page_fetcher: callable, page_size=100):
+    def __init__(self, page_fetcher: callable, page_size: Optional[int]):
         self._page_fetcher = page_fetcher
-        self._page_size = page_size
+        self._page_size = page_size or 100
         self._exhausted = False
         self._start_cursor = None
 

--- a/src/normlite/notiondbapi/resultset.py
+++ b/src/normlite/notiondbapi/resultset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from operator import itemgetter
-import pdb
-from typing import Any, Callable, Optional, Sequence
+from typing import Optional
 
 from normlite._constants import SpecialColumns
 from normlite.notiondbapi.dbapi2_consts import DBAPITypeCode
@@ -123,6 +122,18 @@ class ResultSet:
         # the result set contains pages
         # each entry in the result set provides ids
         return [(self._pg_oid_getter(r),) for r in self._rows]
+
+    def extend_from_json(self, notion_obj: dict) -> None:
+        """Grow the current risult set with a new Notion result object.
+
+        .. versionadded:: 0.11.0
+            New API to handle streaming result over Notion token pagination.
+
+        Args:
+            notion_obj (dict): The Notion result object whose "results" objects need to be added.
+        """
+        other = ResultSet.from_json(self._description, notion_obj)
+        self._rows.extend(other._rows)
             
     @classmethod
     def _process_page(

--- a/tests/unit/engine/test_streaming.py
+++ b/tests/unit/engine/test_streaming.py
@@ -7,10 +7,13 @@ and gates it to the user-facing ``Select`` path. These tests pin the engine-leve
 observable behavior.
 """
 
+import pytest
+
 from normlite.engine.base import Engine
 from normlite.engine.context import ExecutionContext
 from normlite.engine.interfaces import _distill_params
-from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection
+from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection, OperationalError
+from normlite.notion_sdk.client import NotionError
 from normlite.sql.dml import delete, select
 from normlite.sql.schema import Table
 
@@ -40,6 +43,146 @@ class _CallCountingClient:
 
     def __getattr__(self, name):
         return getattr(self._wrapped, name)
+
+
+class _FailOnPageNClient:
+    """Transparent proxy that injects a backend failure on the *N*-th page pull.
+
+    Same wrap-and-delegate shape as ``_CallCountingClient``, but the ``fail_on``-th
+    ``databases.query`` call raises a ``NotionError`` instead of returning a page.
+    This is how Slice 5 reproduces a failure that strikes *mid-stream* — after
+    ``execute()`` has already handed back page 1, when a later lazy page pull is
+    the thing that goes wrong.
+    """
+
+    def __init__(self, wrapped, fail_on=2, code="rate_limited"):
+        self._wrapped = wrapped
+        self.fail_on = fail_on
+        self.code = code
+        self.query_calls = 0
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            self.query_calls += 1
+            if self.query_calls == self.fail_on:
+                raise NotionError("rate limited", status_code=429, code=self.code)
+        return self._wrapped(endpoint, request, path_params, query_params, payload)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def test_streaming_select_propagates_a_mid_stream_page_failure_as_dbapi_error(
+    engine: Engine,
+    students: Table,
+):
+    """A backend failure on page 2 of a streamed ``Select`` surfaces *honestly* at
+    the iteration boundary — page-1 rows already in hand, then a mapped DBAPI error.
+
+    Invariant tested (the Slice-5 headline user story)
+        - A failure that strikes *after* ``execute()`` — when a later page is
+          lazily pulled — must **propagate**, not silently truncate the stream.
+        - It must arrive as the **mapped DBAPI class** (``rate_limited`` ->
+          ``OperationalError``), with the raw ``NotionError`` preserved as
+          ``__cause__`` — i.e. routed through ``Cursor._translate_notion_error``,
+          exactly as a page-1 failure raised inside ``execute()`` already is.
+        - Rows the caller already pulled (page 1) **stay pulled**: the failure does
+          not retroactively empty or rewind the result it already handed back.
+
+    6 rows, ``yield_per=2`` -> backend pages of 2, 2, 2; the fake fails the 2nd
+    ``databases.query``. The first ``fetchmany(2)`` is satisfied entirely from the
+    buffered page 1 (no pull). The second ``fetchmany(2)`` drains the buffer and
+    must pull page 2 — which is where the injected failure lands.
+
+    Three failure modes are fenced off (the anti-patterns the slice must avoid):
+        - **Raw leak** (today): the page pull raises the unmapped ``NotionError``
+          straight up -> ``isinstance(exc, OperationalError)`` is False, no
+          ``__cause__`` chain.
+        - **Swallow-to-empty**: the pull failure is caught and the stream ends
+          quietly -> the second ``fetchmany`` returns ``[]`` and nothing raises.
+        - **Skip-and-continue** (``executemany``'s pattern, wrong here): the failed
+          page is dropped and iteration jumps to page 3 -> rows surface instead of
+          an error; later pages are unreachable past a failure anyway.
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    failing = _FailOnPageNClient(engine._client, fail_on=2)
+    engine._dbapi_connection = DBAPIConnection(failing)
+
+    with engine.connect() as conn:
+        conn = conn.execution_options(stream_results=True, yield_per=2)
+        result = conn.execute(select(students))
+
+        # Page 1 is buffered by execute(): the caller gets these rows cleanly.
+        page_one = result.fetchmany(2)
+        assert len(page_one) == 2
+
+        # Crossing into page 2 triggers the injected backend failure. It must
+        # propagate as the mapped DBAPI class, not the raw NotionError, not [].
+        with pytest.raises(OperationalError) as excinfo:
+            result.fetchmany(2)
+
+    # The raw backend error is preserved on the chain (raise ... from ne).
+    assert isinstance(excinfo.value.__cause__, NotionError)
+    assert excinfo.value.__cause__.code == "rate_limited"
+
+
+def test_streaming_select_all_propagates_a_mid_stream_page_failure_as_dbapi_error(
+    engine: Engine,
+    students: Table,
+):
+    """The ``CursorResult.all()`` "materialize everything" façade fails *loudly* when
+    a page it must drain goes wrong — same honest propagation as the lazy path.
+
+    Where the first mid-stream test drove the *incremental* surface
+    (``fetchmany``, which pulls through ``Cursor.fetchone`` / ``_try_fetch_next``),
+    this drives the *drain-to-completion* surface: ``CursorResult.all()`` (and its
+    synonyms ``fetchall()`` / ``for row in result``) all funnel through
+    ``Cursor._iter_all`` — a *separate* page-pull loop that the first slice did not
+    touch.
+
+    Invariant tested
+        - ``all()`` is all-or-nothing: if a page it must pull fails, the whole call
+          raises the **mapped DBAPI class** (``rate_limited`` -> ``OperationalError``)
+          with the raw ``NotionError`` as ``__cause__`` — routed through
+          ``Cursor._translate_notion_error`` exactly like the lazy path now is.
+        - It must NOT hand back a *truncated* result (page-1 rows dressed up as the
+          complete set) and swallow the failure: ``all()`` promises *every* row or
+          an error, never a silent short read.
+
+    6 rows, ``yield_per=2`` -> backend pages of 2, 2, 2; the fake fails the 2nd
+    ``databases.query``. ``execute`` buffers page 1; ``all()`` then drives the drain
+    and hits the injected failure pulling page 2.
+
+    Failure modes fenced off (all collapse the ``raises`` assertion):
+        - **Raw leak** (today): ``_iter_all``'s ``next(self._page_iter)`` is
+          unwrapped, so the unmapped ``NotionError`` escapes -> not an
+          ``OperationalError``, no ``__cause__`` chain.
+        - **Swallow-to-truncated**: the drain stops quietly at the failed page and
+          ``all()`` returns just the 2 buffered rows -> nothing raises.
+        - **Skip-and-continue**: page 2 is dropped and the drain resumes at page 3
+          -> ``all()`` returns rows instead of raising.
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    failing = _FailOnPageNClient(engine._client, fail_on=2)
+    engine._dbapi_connection = DBAPIConnection(failing)
+
+    with engine.connect() as conn:
+        conn = conn.execution_options(stream_results=True, yield_per=2)
+        result = conn.execute(select(students))
+
+        # all() must drain every page; pulling page 2 hits the injected failure.
+        # It surfaces as the mapped DBAPI class, never a truncated 2-row result.
+        with pytest.raises(OperationalError) as excinfo:
+            result.all()
+
+    assert isinstance(excinfo.value.__cause__, NotionError)
+    assert excinfo.value.__cause__.code == "rate_limited"
 
 
 def test_streaming_select_fetchmany_pulls_only_the_pages_it_needs(

--- a/tests/unit/engine/test_streaming.py
+++ b/tests/unit/engine/test_streaming.py
@@ -1,0 +1,252 @@
+"""Engine-level streaming behavior (issue #327, Slice 4 of ADR-0010).
+
+Slice 3 taught the DBAPI ``Cursor`` to stream over token pagination, but the
+opt-in lived entirely on ``Cursor.execute(..., stream_results=, yield_per=)``.
+Slice 4 plumbs that opt-in down from the engine's ``ExecutionOptions`` cascade
+and gates it to the user-facing ``Select`` path. These tests pin the engine-level
+observable behavior.
+"""
+
+from normlite.engine.base import Engine
+from normlite.engine.context import ExecutionContext
+from normlite.engine.interfaces import _distill_params
+from normlite.notiondbapi.dbapi2 import Connection as DBAPIConnection
+from normlite.sql.dml import delete, select
+from normlite.sql.schema import Table
+
+from tests.utils.db_helpers import (
+    create_students_db,
+    attach_table_oid,
+    populate_students,
+)
+
+
+class _CallCountingClient:
+    """Transparent proxy that counts ``databases.query`` calls and delegates the rest.
+
+    Laziness is only observable by *counting backend calls* — the row totals look
+    identical whether we drained eagerly or streamed. Same idiom as the Slice-3
+    DBAPI tests (``tests/unit/notiondbapi/test_dbapi2.py``), lifted to the engine.
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+        self.query_calls = 0
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            self.query_calls += 1
+        return self._wrapped(endpoint, request, path_params, query_params, payload)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def test_streaming_select_fetchmany_pulls_only_the_pages_it_needs(
+    engine: Engine,
+    students: Table,
+):
+    """A streamed ``Select`` drives ``fetchmany`` across a page boundary, pulling
+    exactly the pages it needs and no more.
+
+    Invariant tested
+        - ``yield_per`` cascades engine -> connection -> DBAPI cursor (Slice 4
+          job 1): the ``Select`` streams instead of draining every page up front.
+        - ``fetchmany(n)`` pulls forward across page boundaries to satisfy ``n``
+          (closes the Slice-3 gap where ``Cursor.fetchmany`` only read the buffer),
+          while leaving later pages unfetched.
+
+    6 rows, ``yield_per=2`` -> request page_size 2 -> backend pages of 2, 2, 2.
+    ``fetchmany(3)`` needs the 3rd row, which lives on page 2, so it must pull
+    page 2 (the 2nd call) — but page 3 (rows 5-6) must stay unfetched.
+
+    Two failure modes are fenced off by the ``query_calls == 2`` assertion:
+        - ``yield_per`` not cascaded: ``page_size`` stays at the engine default
+          (100), so all 6 rows arrive in a single page -> only 1 call (today's red).
+        - ``Cursor.fetchmany`` buffer-only: it can't reach page 2, so it surfaces
+          just the 2 buffered rows (``len(first_three) == 2``).
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    # Count backend page pulls. Seeding is done; only the read below counts.
+    counting = _CallCountingClient(engine._client)
+    engine._dbapi_connection = DBAPIConnection(counting)
+
+    with engine.connect() as conn:
+        conn = conn.execution_options(stream_results=True, yield_per=2)
+        result = conn.execute(select(students))
+
+        first_three = result.fetchmany(3)
+
+    # The 3rd row lives on page 2: fetchmany had to pull it.
+    assert len(first_three) == 3
+    # Exactly two pages pulled (1 + 2); page 3 (rows 5-6) stays unfetched.
+    assert counting.query_calls == 2
+
+
+def test_streaming_select_all_materializes_by_draining_every_page(
+    engine: Engine,
+    students: Table,
+):
+    """A streamed ``Select`` consumed via ``CursorResult.all()`` materializes
+    *every* row by draining all remaining pages.
+
+    Invariant tested
+        - ``all()`` is the "give me everything" façade: on a streamed result it
+          must drive the lazy ``PageIterator`` to exhaustion, not just hand back
+          the single page buffered by ``execute`` (Slice-4 failure mode: ``all()``
+          short-circuiting the drain).
+
+    6 rows, ``yield_per=2`` -> backend pages of 2, 2, 2. ``execute`` buffers only
+    page 1; ``all()`` must pull pages 2 and 3 to return all 6 rows.
+
+    Failure mode fenced off:
+        - ``all()`` reads only the buffered result set (today ``Cursor._iter_all``
+          iterates ``_result_sets`` and never touches ``_page_iter``): it surfaces
+          just the 2 page-1 rows (``len(rows) == 2``, ``query_calls == 1``).
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    counting = _CallCountingClient(engine._client)
+    engine._dbapi_connection = DBAPIConnection(counting)
+
+    with engine.connect() as conn:
+        conn = conn.execution_options(stream_results=True, yield_per=2)
+        result = conn.execute(select(students))
+
+        rows = result.all()
+
+    # all() materialized the whole stream, not just the buffered first page.
+    assert len(rows) == 6
+    # It drained by pulling every page (1 + 2 + 3).
+    assert counting.query_calls == 3
+
+
+def test_do_execute_ignores_streaming_unless_caller_declares_streamable(
+    engine: Engine,
+    students: Table,
+):
+    """``do_execute`` honors the streaming opt-in only when the caller declares
+    the statement streamable — the Select-only gate (ADR-0010).
+
+    Invariant tested
+        - Streaming is **opt-in and Select-only**: honored only on the
+          user-facing ``Select`` read path. Internal full-scan consumers —
+          two-phase ``Delete``/``Update`` and join phase-1 (``dml.py`` ~776/857/939)
+          — call ``do_execute`` *without* declaring streamability, so an inherited
+          ``stream_results=True`` must NOT make them stream. Phase 1 must drain the
+          full match set before phase 2 can run.
+        - The gate is **explicit**, not green-by-omission: ``do_execute`` itself
+          refuses to stream unless told ``streamable``, so a future ``dml.py`` edit
+          that forwards ``execution_options`` into a phase-1 call still cannot
+          silently start streaming.
+
+    This drives the ``do_execute`` chokepoint directly (mirroring the
+    ``dml.py`` phase-1 callers via ``ExecutionContext``): it forwards streaming
+    options but leaves ``streamable`` at its default. The operation is a paginated
+    ``databases.query`` (the only paginated endpoint) purely so streaming-vs-draining
+    is observable.
+
+    6 rows, ``yield_per=2`` -> request page_size 2 -> backend pages of 2, 2, 2.
+    Drain-all keeps the ``rowcount`` contract: accurate immediately. Streaming
+    would leave the page iterator unexhausted -> ``rowcount == -1``.
+
+    Failure mode fenced off:
+        - No gate (today): ``do_execute`` passes ``stream_results``/``yield_per``
+          straight through, so ``execute`` buffers only page 1 and the page
+          iterator stays unexhausted -> ``rowcount == -1``.
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    # Build the paginated databases.query operation + a description-injected
+    # cursor the way the real phase-1 callers do, via the execution context.
+    compiled = select(students).compile(engine._sql_compiler)
+    cursor = engine.raw_connection().cursor()
+    ctx = ExecutionContext(
+        engine,
+        engine.connect(),
+        cursor=cursor,
+        compiled=compiled,
+        distilled_params=_distill_params(None),
+        execution_options={},
+    )
+    ctx.pre_exec()
+    ctx.invoked_stmt._setup_execution(ctx)
+
+    # The caller forwards the inherited streaming options but does NOT declare
+    # the statement streamable — exactly the Delete/Update/join phase-1 contract.
+    engine.do_execute(
+        cursor,
+        ctx.operation,
+        ctx.parameters,
+        execution_options={"stream_results": True, "yield_per": 2},
+    )
+
+    # Drain-all preserved: the count is accurate immediately, not -1.
+    assert cursor.rowcount == 6
+    assert len(cursor.fetchall()) == 6
+
+
+def test_two_phase_delete_ignores_streaming_and_reports_accurate_rowcount(
+    engine: Engine,
+    students: Table,
+):
+    """A two-phase ``Delete`` on a ``stream_results=True`` connection still drains
+    its full phase-1 match set as one page and deletes every matched row.
+
+    This is the slice's headline user story — *streaming never corrupts a
+    mutation* — driven end-to-end through the real ``conn.execute`` pipeline (not
+    the synthetic ``do_execute`` call of the gate test above).
+
+    Invariant tested
+        - Streaming is **Select-only** (ADR-0010). A ``Delete`` is dispatched on
+          the EXECUTEMANY channel; its phase-1 read (``dml.py`` ~939) calls
+          ``do_execute`` *without* declaring streamability, so the connection's
+          inherited ``stream_results``/``yield_per`` must NOT reach it. Phase 1
+          must run as a single drain-all page (request ``page_size`` 100), never
+          fragmented by ``yield_per``.
+        - Correctness: every matched row reaches phase 2, so ``rowcount`` is the
+          full match count, not just one streamed page.
+
+    Why ``query_calls`` is the discriminator, not ``rowcount`` alone
+        Phase 1 immediately ``fetchall()``s its rows (``dml.py:947``), and
+        ``fetchall`` drains the page iterator to exhaustion. So even a *broken*
+        gate that streamed phase 1 would recover all rows on that drain and still
+        report ``rowcount == 6`` — ``rowcount`` can't see the leak. The leak shows
+        up only in *how many backend pages* phase 1 pulled: an inherited
+        ``yield_per=2`` would fragment the request into ``page_size`` 2, so the
+        ``fetchall`` drain would pull pages 2 and 3 as well.
+
+    6 active rows, connection ``yield_per=2``:
+        - gate honored (today): phase-1 request ``page_size`` 100 -> all 6 rows in
+          one page -> ``query_calls == 1``.
+        - gate broken: phase-1 forwards ``yield_per=2`` -> ``page_size`` 2 ->
+          ``fetchall`` drains pages 1, 2, 3 -> ``query_calls == 3``.
+
+    Failure mode fenced off:
+        - Select-only gate bypassed for mutations: a future ``dml.py`` edit that
+          threads ``execution_options``/``streamable`` into the Delete phase-1
+          call fragments the mutation's read -> ``query_calls == 3``.
+    """
+    db_id = create_students_db(engine)
+    attach_table_oid(students, db_id)
+    populate_students(engine, students, n=6)
+
+    counting = _CallCountingClient(engine._client)
+    engine._dbapi_connection = DBAPIConnection(counting)
+
+    with engine.connect() as conn:
+        conn = conn.execution_options(stream_results=True, yield_per=2)
+        result = conn.execute(delete(students).where(students.c.is_active.is_(True)))
+
+    # Every matched row was deleted: phase 1 saw the whole match set, not a page.
+    assert result.rowcount == 6
+    # Phase 1 drained as a single page (page_size 100): the connection's yield_per
+    # never reached the mutation's read. A leak would surface as 3 pulls.
+    assert counting.query_calls == 1

--- a/tests/unit/notion_sdk/test_notion_sdk_in_memory_client.py
+++ b/tests/unit/notion_sdk/test_notion_sdk_in_memory_client.py
@@ -427,6 +427,103 @@ def test_databases_query_does_not_return_deleted_pages_if_in_trash_false(client)
     ids = {p["id"] for p in result["results"]}
     assert ids == {p2["id"]}
 
+def test_databases_query_paginates_with_page_size_and_cursor(client):
+    db = client.databases_create(
+        payload=make_database(client._ROOT_PAGE_ID_)
+    )
+
+    p1 = client.pages_create(payload=make_db_page(db["id"], "Alice", 20))
+    p2 = client.pages_create(payload=make_db_page(db["id"], "Bob", 30))
+    p3 = client.pages_create(payload=make_db_page(db["id"], "Carol", 40))
+
+    # First page: ask for 2 of the 3 matching rows.
+    page_one = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"page_size": 2},
+    )
+
+    assert len(page_one["results"]) == 2
+    assert page_one["has_more"] is True
+    assert page_one["next_cursor"] is not None
+
+    # Second page: hand the cursor back to fetch the remainder.
+    page_two = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"page_size": 2, "start_cursor": page_one["next_cursor"]},
+    )
+
+    assert len(page_two["results"]) == 1
+    assert page_two["has_more"] is False
+    assert page_two["next_cursor"] is None
+
+    # The two pages together are all 3 rows, in order, with no overlap.
+    seen_ids = [p["id"] for p in page_one["results"]] + \
+               [p["id"] for p in page_two["results"]]
+    assert seen_ids == [p1["id"], p2["id"], p3["id"]]
+
+
+def test_databases_query_last_page_when_rows_are_exact_multiple_of_page_size(client):
+    db = client.databases_create(
+        payload=make_database(client._ROOT_PAGE_ID_)
+    )
+
+    # 4 rows with page_size=2 → the set drains exactly on page 2.
+    client.pages_create(payload=make_db_page(db["id"], "Alice", 20))
+    client.pages_create(payload=make_db_page(db["id"], "Bob", 30))
+    client.pages_create(payload=make_db_page(db["id"], "Carol", 40))
+    client.pages_create(payload=make_db_page(db["id"], "Dave", 50))
+
+    page_one = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"page_size": 2},
+    )
+    page_two = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"page_size": 2, "start_cursor": page_one["next_cursor"]},
+    )
+
+    # The second page exactly drains the set: no phantom page beyond it.
+    assert len(page_two["results"]) == 2
+    assert page_two["has_more"] is False
+    assert page_two["next_cursor"] is None
+
+
+def test_databases_query_paginates_the_filtered_set_not_the_raw_store(client):
+    db = client.databases_create(
+        payload=make_database(client._ROOT_PAGE_ID_)
+    )
+
+    # 5 rows in the store, but only 3 match the filter.
+    m1 = client.pages_create(payload=make_db_page(db["id"], "Alice", 30))
+    client.pages_create(payload=make_db_page(db["id"], "Bob", 99))
+    m2 = client.pages_create(payload=make_db_page(db["id"], "Carol", 30))
+    client.pages_create(payload=make_db_page(db["id"], "Dave", 99))
+    m3 = client.pages_create(payload=make_db_page(db["id"], "Eve", 30))
+
+    age_is_30 = {"property": "Age", "number": {"equals": 30}}
+
+    page_one = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"filter": age_is_30, "page_size": 2},
+    )
+    page_two = client.databases_query(
+        path_params={"database_id": db["id"]},
+        payload={"filter": age_is_30, "page_size": 2, "start_cursor": page_one["next_cursor"]},
+    )
+
+    # Page sizes follow the filtered set (3 matches → 2 then 1), not the raw store (5).
+    assert len(page_one["results"]) == 2
+    assert page_one["has_more"] is True
+    assert len(page_two["results"]) == 1
+    assert page_two["has_more"] is False
+    assert page_two["next_cursor"] is None
+
+    # Only the matching rows appear, in order; the non-matching rows are never paged in.
+    seen_ids = [p["id"] for p in page_one["results"]] + \
+               [p["id"] for p in page_two["results"]]
+    assert seen_ids == [m1["id"], m2["id"], m3["id"]]
+
+
 def test_databases_query_returns_deleted_pages_if_in_trash_true(client):
     db = client.databases_create(
         payload=make_database(client._ROOT_PAGE_ID_)

--- a/tests/unit/notiondbapi/test_dbapi2.py
+++ b/tests/unit/notiondbapi/test_dbapi2.py
@@ -5,9 +5,15 @@ import uuid
 import pytest
 from faker import Faker
 
-from normlite.notion_sdk.client import InMemoryNotionClient
+from normlite.notion_sdk.client import InMemoryNotionClient, NotionError
 from normlite.notion_sdk.getters import rich_text_to_plain_text
-from normlite.notiondbapi.dbapi2 import Connection, Cursor, ProgrammingError
+from normlite.notiondbapi.dbapi2 import (
+    Connection,
+    Cursor,
+    DatabaseError,
+    OperationalError,
+    ProgrammingError,
+)
 
 @pytest.fixture
 def client() -> InMemoryNotionClient:
@@ -717,6 +723,144 @@ def test_streaming_fetchall_returns_all_rows_in_order(
     assert actual_names == expected_names
     assert cursor.rowcount == 5
     assert cursor.fetchone() is None      # fully consumed across all pages
+
+
+class _FailOnPageNClient:
+    """Transparent proxy that raises a NotionError on the ``fail_on``-th query.
+
+    Same wrap-and-delegate shape as ``_CallCountingClient``, but the chosen
+    ``databases.query`` call fails instead of returning a page — reproducing a
+    backend failure that strikes *mid-stream*, when a later page is pulled.
+    """
+
+    def __init__(self, wrapped, fail_on=2, code="rate_limited"):
+        self._wrapped = wrapped
+        self.fail_on = fail_on
+        self.code = code
+        self.query_calls = 0
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            self.query_calls += 1
+            if self.query_calls == self.fail_on:
+                raise NotionError("rate limited", status_code=429, code=self.code)
+        return self._wrapped(endpoint, request, path_params, query_params, payload)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def test_streaming_fetchall_propagates_a_mid_stream_page_failure_as_dbapi_error(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    """``Cursor.fetchall`` drains a stream to completion — and when a page it must
+    pull fails, it surfaces the *mapped* DBAPI error, not the raw NotionError.
+
+    The first two mid-stream slices fixed the lazy pull (``fetchone`` /
+    ``_try_fetch_next``) and the engine drain façade (``_iter_all``). This pins the
+    *third* page-pull loop: ``Cursor.fetchall``'s own ``while not exhausted`` drain
+    (``dbapi2.py`` ~582). No engine ``CursorResult`` surface routes through it —
+    ``all()``/``fetchall()``/iteration all go via ``_iter_all`` — but it is the
+    PEP 249 public ``fetchall``, so a direct DBAPI consumer streaming a result and
+    calling it must get the same honest propagation contract as every other pull
+    point: ``rate_limited`` -> ``OperationalError`` with the ``NotionError`` as
+    ``__cause__`` (routed through ``Cursor._translate_notion_error``).
+
+    5 rows, ``page_size``/``yield_per`` 2 -> backend pages of 2, 2, 1; the fake
+    fails the 2nd ``databases.query``. ``execute`` buffers page 1; ``fetchall``
+    then drains and hits the injected failure pulling page 2.
+
+    Failure modes fenced off (each collapses the ``raises`` assertion):
+        - **Raw leak** (today): the drain's ``next(self._page_iter)`` is unwrapped,
+          so the unmapped ``NotionError`` escapes -> not an ``OperationalError``.
+        - **Swallow-to-truncated**: the drain stops quietly at the failed page and
+          ``fetchall`` returns just the 2 buffered rows -> nothing raises.
+        - **Skip-and-continue**: page 2 is dropped, the drain resumes at page 3 ->
+          rows come back instead of an error.
+    """
+    failing = _FailOnPageNClient(client, fail_on=2)
+    cursor = Cursor(Connection(failing))
+    database_id, _ = generate_pages(client, n=5)
+    cursor._inject_description(row_description)
+
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": {
+                "page_size": 2,
+                "filter": {"property": "is_active", "checkbox": {"does_not_equal": True}},
+            },
+        },
+        stream_results=True,
+        yield_per=2,
+    )
+
+    # Page 1 buffered (1 call); fetchall must drain, and pulling page 2 fails.
+    with pytest.raises(OperationalError) as excinfo:
+        cursor.fetchall()
+
+    assert isinstance(excinfo.value.__cause__, NotionError)
+    assert excinfo.value.__cause__.code == "rate_limited"
+
+
+class _MalformedPageClient:
+    """Minimal client whose ``databases.query`` returns a malformed page.
+
+    ``has_more=True`` with ``next_cursor=None`` is the contradiction
+    ``PageIterator`` rejects: it can't honor "there are more pages" without a
+    cursor to fetch them. The iterator raises ``ValueError`` on the pull, which
+    ``execute()`` must translate into a DBAPI ``DatabaseError`` rather than leak.
+    """
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            return {"object": "list", "results": [], "has_more": True, "next_cursor": None}
+        raise AssertionError(f"unexpected backend call: {endpoint}.{request}")
+
+
+def test_execute_translates_malformed_page_into_dbapi_database_error(
+    row_description: tuple[tuple, ...],
+):
+    """A malformed page during ``execute()``'s eager drain surfaces as a
+    ``DatabaseError`` carrying a *descriptive* message, not a bare error.
+
+    This pins the Slice-2 contract (a malformed Notion result becomes a DBAPI
+    Error instead of leaking ``ValueError``) — a translation path that lived only
+    in ``execute()``'s inline ``except ValueError`` and had no direct test. It
+    also guards the consolidation that routes ``execute()`` through
+    ``_translate_notion_error``: that helper's ``ValueError`` branch produces the
+    descriptive message, so this test is the discriminator between the old bare
+    ``DatabaseError()`` and the unified message.
+
+    ``has_more=True`` + ``next_cursor=None`` makes ``PageIterator.__next__`` raise
+    ``ValueError`` on the very first (page-1) pull inside ``execute()``'s drain.
+
+    Failure modes fenced off:
+        - **Raw leak**: the ``ValueError`` escapes untranslated -> not a
+          ``DatabaseError``.
+        - **Uninformative wrap**: a bare ``DatabaseError()`` with no message ->
+          the ``"has_more"``/``"start_cursor"`` assertions fail, leaving operators
+          to guess what broke.
+    """
+    cursor = Cursor(Connection(_MalformedPageClient()))
+    cursor._inject_description(row_description)
+
+    with pytest.raises(DatabaseError) as excinfo:
+        cursor.execute(
+            operation={"endpoint": "databases", "request": "query"},
+            parameters={
+                "path_params": {"database_id": "db-1"},
+                "payload": {"filter": {"property": "is_active", "checkbox": {"equals": True}}},
+            },
+        )
+
+    # The malformed page is the documented cause; the message must name the defect.
+    message = str(excinfo.value)
+    assert "has_more" in message
+    assert "start_cursor" in message
+    assert isinstance(excinfo.value.__cause__, ValueError)
 
 
 def test_yield_per_sets_clamped_request_page_size(

--- a/tests/unit/notiondbapi/test_dbapi2.py
+++ b/tests/unit/notiondbapi/test_dbapi2.py
@@ -522,6 +522,26 @@ class _CallCountingClient:
         return getattr(self._wrapped, name)
 
 
+class _PayloadSpyClient:
+    """Transparent proxy that records the payload of each databases.query call.
+
+    ``page_size`` is internal (derived from ``yield_per``), so the only way to
+    observe it is to capture the request body the backend actually received.
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+        self.query_payloads = []
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            self.query_payloads.append(payload)
+        return self._wrapped(endpoint, request, path_params, query_params, payload)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
 def test_streaming_execute_fetches_only_first_page(
     client: InMemoryNotionClient,
     row_description: tuple[tuple, ...],
@@ -697,6 +717,41 @@ def test_streaming_fetchall_returns_all_rows_in_order(
     assert actual_names == expected_names
     assert cursor.rowcount == 5
     assert cursor.fetchone() is None      # fully consumed across all pages
+
+
+def test_yield_per_sets_clamped_request_page_size(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # yield_per IS the internal Notion page_size, clamped to the API max of 100:
+    # page_size = min(yield_per or 100, 100). The caller carries NO page_size in
+    # the payload — the cursor injects it from yield_per, on a per-request copy
+    # (never smearing it onto the caller's dict).
+    database_id, _ = generate_pages(client, n=3)
+    spy = _PayloadSpyClient(client)
+    cursor = Cursor(Connection(spy))
+    cursor._inject_description(row_description)
+
+    payload = {"filter": {"property": "is_active", "checkbox": {"does_not_equal": True}}}
+
+    # Sub-cap: yield_per passes straight through as the request page_size.
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={"path_params": {"database_id": database_id}, "payload": payload},
+        yield_per=2,
+    )
+    assert spy.query_payloads[-1].get("page_size") == 2
+    # internal page_size must not be smeared onto the caller's payload dict.
+    assert "page_size" not in payload
+
+    # Above-cap: clamped to the Notion API maximum of 100 (so yield_per > 100
+    # pulls multiple Notion pages per logical batch).
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={"path_params": {"database_id": database_id}, "payload": payload},
+        yield_per=200,
+    )
+    assert spy.query_payloads[-1].get("page_size") == 100
 
 #----------------------------------------------------------------
 # lastrowid tests

--- a/tests/unit/notiondbapi/test_dbapi2.py
+++ b/tests/unit/notiondbapi/test_dbapi2.py
@@ -441,6 +441,62 @@ def test_rowcount_returns_count_of_all_rows_found(
     assert n_pages == cursor.rowcount
 
 #----------------------------------------------------------------
+# drain-all pagination tests (issue #325)
+#----------------------------------------------------------------
+
+def test_execute_drains_every_page_into_one_result_set(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # Arrange: 5 matching rows, but force the backend to hand them back two at a
+    # time. page_size lives in the caller payload here purely to provoke a 2+2+1
+    # token walk cheaply — in production callers omit it and the client defaults
+    # to 100, where the same drain loop still applies above 100 rows.
+    cursor = Cursor(Connection(client))
+    database_id, pages = generate_pages(client, n=5)
+    cursor._inject_description(row_description)
+
+    payload = {
+        "page_size": 2,
+        "filter": {
+            "property": "is_active",
+            "checkbox": {"does_not_equal": True},
+        },
+    }
+
+    # Act: a SINGLE execute() must transparently follow next_cursor across all
+    # three pages — the caller never sees pagination.
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": payload,
+        },
+    )
+    rows = cursor.fetchall()
+
+    # Assert: all five rows surfaced, in insertion order, as ONE result set.
+    # (If a page were modelled as its own ResultSet, fetchall would see only the
+    # first 2 rows even though rowcount summed to 5 — so the names pin order AND
+    # the single-result-set shape, not just the count.)
+    # pages_create strips properties to ids only, so retrieve each created page
+    # to recover the title values for the expected side.
+    created_pages = [
+        client("pages", "retrieve", path_params={"page_id": p["id"]}) for p in pages
+    ]
+    expected_names = [
+        rich_text_to_plain_text(p["properties"]["name"]["title"]) for p in created_pages
+    ]
+    actual_names = [rich_text_to_plain_text(get_name(r)["title"]) for r in rows]
+    assert actual_names == expected_names
+    assert cursor.rowcount == 5
+    assert cursor.fetchone() is None      # result set fully consumed, no second set
+
+    # And the drain rebuilt the body per fetch: the moving start_cursor was never
+    # smeared onto the caller's shared payload dict.
+    assert "start_cursor" not in payload
+
+#----------------------------------------------------------------
 # lastrowid tests
 #----------------------------------------------------------------
 

--- a/tests/unit/notiondbapi/test_dbapi2.py
+++ b/tests/unit/notiondbapi/test_dbapi2.py
@@ -497,6 +497,208 @@ def test_execute_drains_every_page_into_one_result_set(
     assert "start_cursor" not in payload
 
 #----------------------------------------------------------------
+# lazy streaming pagination tests (issue #326)
+#----------------------------------------------------------------
+
+class _CallCountingClient:
+    """Transparent proxy that counts databases.query calls and delegates the rest.
+
+    Laziness is only observable by *counting backend calls* — row totals look
+    identical whether we drained eagerly or streamed. So we spy on the one call
+    the cursor makes (``self._client(endpoint, request, ...)``) and forward
+    everything else (``_add``, ``pages_create``, ``_ensure_root`` …) untouched.
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+        self.query_calls = 0
+
+    def __call__(self, endpoint, request, path_params=None, query_params=None, payload=None):
+        if endpoint == "databases" and request == "query":
+            self.query_calls += 1
+        return self._wrapped(endpoint, request, path_params, query_params, payload)
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def test_streaming_execute_fetches_only_first_page(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # Arrange: 5 matching rows handed back two at a time (page_size=2 forces a
+    # 2+2+1 token walk). A counting proxy records how many databases.query calls
+    # actually reach the backend.
+    database_id, _ = generate_pages(client, n=5)
+    counting = _CallCountingClient(client)
+    cursor = Cursor(Connection(counting))
+    cursor._inject_description(row_description)
+
+    payload = {
+        "page_size": 2,
+        "filter": {
+            "property": "is_active",
+            "checkbox": {"does_not_equal": True},
+        },
+    }
+
+    # Act: stream the result — execute() must pull page 1 only.
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": payload,
+        },
+        stream_results=True,
+        yield_per=2,
+    )
+
+    # Assert: exactly one backend call so far. Drain-all would have made three
+    # (2+2+1); streaming defers pages 2 and 3 until they're fetched.
+    assert counting.query_calls == 1
+
+
+def test_streaming_pulls_next_page_on_demand(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # Arrange: 5 rows, page_size 2 → backend pages of 2, 2, 1. Stream them.
+    database_id, _ = generate_pages(client, n=5)
+    counting = _CallCountingClient(client)
+    cursor = Cursor(Connection(counting))
+    cursor._inject_description(row_description)
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": {
+                "page_size": 2,
+                "filter": {"property": "is_active", "checkbox": {"does_not_equal": True}},
+            },
+        },
+        stream_results=True,
+        yield_per=2,
+    )
+
+    # The first page (2 rows) is already buffered — draining it makes no new call.
+    assert cursor.fetchone() is not None
+    assert cursor.fetchone() is not None
+    assert counting.query_calls == 1
+
+    # The third row lives on page 2: fetching it must pull exactly one more page,
+    # and surface real data (not None — which is what dropping the iterator gives).
+    third = cursor.fetchone()
+    assert third is not None
+    assert counting.query_calls == 2
+
+
+def test_streaming_rowcount_is_unknown_until_fully_drained(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # rowcount must NOT leak the buffered page length while a stream is mid-flight.
+    # #326 contract: rowcount stays -1 ("unknown") until every page has been pulled,
+    # then reports the true sum. 5 rows, page_size 2 → pages of 2, 2, 1.
+    database_id, _ = generate_pages(client, n=5)
+    counting = _CallCountingClient(client)
+    cursor = Cursor(Connection(counting))
+    cursor._inject_description(row_description)
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": {
+                "page_size": 2,
+                "filter": {"property": "is_active", "checkbox": {"does_not_equal": True}},
+            },
+        },
+        stream_results=True,
+        yield_per=2,
+    )
+
+    # Mid-stream: only page 1 (2 rows) is buffered, but rowcount must read -1 —
+    # NOT 2. Reporting the buffered length is the explicit failure mode in #326.
+    assert cursor.rowcount == -1
+
+    # Drain the whole stream one row at a time (fetchone drives the lazy page pull).
+    drained = 0
+    while cursor.fetchone() is not None:
+        drained += 1
+    assert drained == 5
+
+    # Fully retrieved: rowcount now reports the true total across all pages.
+    assert cursor.rowcount == 5
+
+
+def test_yield_per_implies_streaming(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # Specifying a batch size is itself the opt-in to lazy streaming: passing
+    # yield_per WITHOUT stream_results must still defer pages 2 and 3. 5 rows,
+    # page_size 2 → a drain-all would make three calls (2+2+1).
+    database_id, _ = generate_pages(client, n=5)
+    counting = _CallCountingClient(client)
+    cursor = Cursor(Connection(counting))
+    cursor._inject_description(row_description)
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": {
+                "page_size": 2,
+                "filter": {"property": "is_active", "checkbox": {"does_not_equal": True}},
+            },
+        },
+        yield_per=2,
+    )
+
+    # No stream_results kwarg, yet only one backend call so far: yield_per implied it.
+    assert counting.query_calls == 1
+
+
+def test_streaming_fetchall_returns_all_rows_in_order(
+    client: InMemoryNotionClient,
+    row_description: tuple[tuple, ...],
+):
+    # End-to-end: a streamed read must surface EVERY row across EVERY page, in
+    # insertion order — the same observable result as a drain-all, just pulled
+    # lazily. 5 rows, page_size 2 → pages of 2, 2, 1. fetchall() is the canonical
+    # full read, so it must drive the lazy page pull to completion and NOT stop at
+    # the buffered first page (which is what list(current_rs) gives today).
+    cursor = Cursor(Connection(client))
+    database_id, pages = generate_pages(client, n=5)
+    cursor._inject_description(row_description)
+
+    cursor.execute(
+        operation={"endpoint": "databases", "request": "query"},
+        parameters={
+            "path_params": {"database_id": database_id},
+            "payload": {
+                "page_size": 2,
+                "filter": {"property": "is_active", "checkbox": {"does_not_equal": True}},
+            },
+        },
+        stream_results=True,
+        yield_per=2,
+    )
+
+    rows = cursor.fetchall()
+
+    # pages_create strips properties to ids only, so retrieve each created page to
+    # recover the title values for the expected side (same shape as the drain-all test).
+    created_pages = [
+        client("pages", "retrieve", path_params={"page_id": p["id"]}) for p in pages
+    ]
+    expected_names = [
+        rich_text_to_plain_text(p["properties"]["name"]["title"]) for p in created_pages
+    ]
+    actual_names = [rich_text_to_plain_text(get_name(r)["title"]) for r in rows]
+    assert actual_names == expected_names
+    assert cursor.rowcount == 5
+    assert cursor.fetchone() is None      # fully consumed across all pages
+
+#----------------------------------------------------------------
 # lastrowid tests
 #----------------------------------------------------------------
 

--- a/tests/unit/notiondbapi/test_page_iterator.py
+++ b/tests/unit/notiondbapi/test_page_iterator.py
@@ -1,0 +1,54 @@
+import pytest
+
+# Adjust the import to wherever you site the deep module.
+from normlite.notiondbapi.page_iterator import PageIterator
+
+
+def test_eager_drain_walks_every_page_in_token_order_then_reports_exhausted():
+    # Arrange: three pages chained by opaque cursor tokens. The row payloads
+    # ("r1".."r5") are deliberately opaque — the iterator must follow the
+    # token protocol without understanding what a row is.
+    pages = {
+        None:    {"results": ["r1", "r2"], "has_more": True,  "next_cursor": "cur-1"},
+        "cur-1": {"results": ["r3", "r4"], "has_more": True,  "next_cursor": "cur-2"},
+        "cur-2": {"results": ["r5"],       "has_more": False, "next_cursor": None},
+    }
+    requested_cursors = []
+
+    def fetch_page(start_cursor):
+        requested_cursors.append(start_cursor)
+        return pages[start_cursor]
+
+    iterator = PageIterator(fetch_page, page_size=2)
+
+    # Act: eager drain — pull every page now.
+    drained = list(iterator)
+
+    # Assert: every page was fetched, in token order, starting from None and
+    # following next_cursor; the walk stopped exactly when has_more went false.
+    assert requested_cursors == [None, "cur-1", "cur-2"]
+    assert [page["results"] for page in drained] == [["r1", "r2"], ["r3", "r4"], ["r5"]]
+    assert iterator.exhausted is True
+
+
+def test_page_claiming_more_with_null_cursor_raises_instead_of_looping_forever():
+    # Arrange: a single malformed page that violates the token protocol — it
+    # claims another page exists (has_more) but hands back no cursor to fetch it.
+    # Following this naively re-fetches start_cursor=None forever.
+    malformed = {"results": ["r1"], "has_more": True, "next_cursor": None}
+    requested_cursors = []
+
+    def fetch_page(start_cursor):
+        requested_cursors.append(start_cursor)
+        return malformed
+
+    iterator = PageIterator(fetch_page, page_size=2)
+
+    # Act / Assert: the contradiction is caught at the first pull and surfaced
+    # loudly, rather than the iterator spinning on a null cursor. (Exception type
+    # is a placeholder — swap for a domain error if the module grows one.)
+    with pytest.raises(ValueError):
+        next(iterator)
+
+    # And it stopped after exactly one fetch — no silent re-walk from the top.
+    assert requested_cursors == [None]


### PR DESCRIPTION
Implements **streaming result over token pagination** (ADR-0010): expose Notion's `has_more`/`next_cursor` pagination as a SQLAlchemy-like streaming result. Built via teaching-driven TDD across vertical slices.

Draft: **Slice 5 (mid-stream error propagation, #328) is still pending** — opening early for visibility.

## Slices in this branch
- **Slice 1 (#324)** — `InMemoryNotionClient.databases_query` honors `page_size`/`start_cursor`, emits real `has_more`/`next_cursor` (opaque UUID offset token).
- **Slice 2 (#325)** — `PageIterator` deep module + `ResultSet.extend_from_json`; **drain-all by default** in `Cursor.execute` (atomic publish — no torn reads). This is the correctness floor that fixes a latent silent-row-drop in joins and two-phase Delete/Update.
- **Slice 3 (#326)** — opt-in lazy streaming via `execute(stream_results=, yield_per=)`; `fetchone` pulls on buffer-drain, `fetchall` drives to completion, `rowcount == -1` until exhausted, `page_size = min(yield_per, 100)` body-injected only when streaming. `executemany` stays non-paginated by design (execute-only boundary).
- **Slice 4 (#327)** — engine cascade + **Select-only gating** + `CursorResult` streaming consumption:
  - `stream_results`/`yield_per` cascade through `ExecutionOptions` (engine → connection → statement).
  - `do_execute` grows a keyword-only `streamable` gate; `_execute_single` passes `streamable=elem.is_select`, so mutations, join phase-1, and reflection keep draining all pages even on a `stream_results=True` connection.
  - `fetchmany` tops up across page boundaries; `_iter_all` drains the iterator so `all()`/`fetchall()` materialize the whole stream; `one()`/`first()` stop early via lazy `fetchone`.

## Tests
`698 passed, 3 skipped`. Engine-level streaming behavior in `tests/unit/engine/test_streaming.py` (call-counting client proves laziness): fetchmany page-crossing, `all()` drain, the `do_execute` gate, and an end-to-end two-phase `Delete` that stays drain-all (accurate `rowcount`) on a streaming connection.

## Known boundary (deferred)
`_reset_results` doesn't clear `_page_iter`: a partially-drained streaming `execute()` followed by `executemany()` on the same cursor could bleed stale pages via `_iter_all`. Exotic; slated for a targeted reset in `executemany` (Slice-5-adjacent).

Part of #323 (PRD). Closes #324, #325, #326, #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)