### PR TITLE
ci: upgrade deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -27,7 +27,7 @@ jobs:
 
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@e48ae95fa406cefacc7fbdd79949122795569961 # v1.8.0
         with:
           pytest-coverage-path: pytest-coverage.txt
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
           uv run sphinx-build -b html docs/ docs/_build/html --color
 
       - name: Upload documentation
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag-and-deploy.yml
+++ b/.github/workflows/tag-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: main
@@ -48,7 +48,7 @@ jobs:
         run: uv run sphinx-build -b html docs/ docs/_build/html --color
 
       - name: Upload documentation artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Upgrades the GitHub Actions referenced across all workflows to current major versions, replacing versions that GitHub is deprecating:

- `actions/checkout` v4 → v5 (ci, docs, release, tag-and-deploy)
- `actions/setup-python` v5 → v6 (docs)
- `actions/upload-pages-artifact` v3 → v5 (docs, tag-and-deploy)
- `actions/deploy-pages` v4 → v5 (docs, tag-and-deploy)
- pin `MishaKav/pytest-coverage-comment` to a tagged SHA (v1.8.0)

These edits existed locally but were never committed; this lands them on `main`. Merging this **before** release PR #331 ensures the post-merge docs deploy in `tag-and-deploy.yml` runs the upgraded `upload-pages-artifact`/`deploy-pages` actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)